### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -61,7 +61,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.1.8");
+		this.setTitle("Java Render Engine v2.1.9");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {

--- a/src/fi/jkauppa/javarenderengine/ModelLib.java
+++ b/src/fi/jkauppa/javarenderengine/ModelLib.java
@@ -35,8 +35,16 @@ public class ModelLib {
 		public BufferedImage specularsnapimage = null;
 		public VolatileImage specularhighfileimage = null;
 		public BufferedImage specularhighsnapimage = null;
+		public VolatileImage emissivefileimage = null;
+		public BufferedImage emissivesnapimage = null;
 		public VolatileImage alphafileimage = null;
 		public BufferedImage alphasnapimage = null;
+		public VolatileImage roughnessfileimage = null;
+		public BufferedImage roughnesssnapimage = null;
+		public VolatileImage metallicfileimage = null;
+		public BufferedImage metallicsnapimage = null;
+		public VolatileImage sheenfileimage = null;
+		public BufferedImage sheensnapimage = null;
 		public VolatileImage bumpfileimage = null;
 		public BufferedImage bumpsnapimage = null;
 		public VolatileImage dispfileimage = null;
@@ -672,6 +680,38 @@ public class ModelLib {
 						File imagefile = new File(savemtlfile.getParent(), savefilename);
 						ImageIO.write(model.materials[i].specularhighfileimage.getSnapshot(), "PNG", imagefile);
 					}
+					if (model.materials[i].emissivefileimage!=null) {
+						String savefilename = model.materials[i].filename;
+						savefilename = savefilename.substring(0, savefilename.length()-4)+"_emissive.png";
+						modelobjfile.write("map_Ke "+savefilename);
+						modelobjfile.newLine();
+						File imagefile = new File(savemtlfile.getParent(), savefilename);
+						ImageIO.write(model.materials[i].emissivefileimage.getSnapshot(), "PNG", imagefile);
+					}
+					if (model.materials[i].roughnessfileimage!=null) {
+						String savefilename = model.materials[i].filename;
+						savefilename = savefilename.substring(0, savefilename.length()-4)+"_roughness.png";
+						modelobjfile.write("map_Pr "+savefilename);
+						modelobjfile.newLine();
+						File imagefile = new File(savemtlfile.getParent(), savefilename);
+						ImageIO.write(model.materials[i].roughnessfileimage.getSnapshot(), "PNG", imagefile);
+					}
+					if (model.materials[i].metallicfileimage!=null) {
+						String savefilename = model.materials[i].filename;
+						savefilename = savefilename.substring(0, savefilename.length()-4)+"_metallic.png";
+						modelobjfile.write("map_Pm "+savefilename);
+						modelobjfile.newLine();
+						File imagefile = new File(savemtlfile.getParent(), savefilename);
+						ImageIO.write(model.materials[i].metallicfileimage.getSnapshot(), "PNG", imagefile);
+					}
+					if (model.materials[i].sheenfileimage!=null) {
+						String savefilename = model.materials[i].filename;
+						savefilename = savefilename.substring(0, savefilename.length()-4)+"_sheen.png";
+						modelobjfile.write("map_Ps "+savefilename);
+						modelobjfile.newLine();
+						File imagefile = new File(savemtlfile.getParent(), savefilename);
+						ImageIO.write(model.materials[i].sheenfileimage.getSnapshot(), "PNG", imagefile);
+					}
 					if (model.materials[i].alphafileimage!=null) {
 						String savefilename = model.materials[i].filename;
 						savefilename = savefilename.substring(0, savefilename.length()-4)+"_alpha.png";
@@ -847,6 +887,26 @@ public class ModelLib {
 					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);
 					    	modelmaterials.get(modelmaterials.size()-1).filename = farg;
 					    	modelmaterials.get(modelmaterials.size()-1).specularfileimage = UtilLib.loadImage(loadimgfile.getPath(), loadresourcefromjar);
+					    }else if (fline.toLowerCase().startsWith("map_ke ")) {
+					    	String farg = fline.substring(7).trim();
+					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);
+					    	modelmaterials.get(modelmaterials.size()-1).filename = farg;
+					    	modelmaterials.get(modelmaterials.size()-1).emissivefileimage = UtilLib.loadImage(loadimgfile.getPath(), loadresourcefromjar);
+					    }else if (fline.toLowerCase().startsWith("map_pr ")) {
+					    	String farg = fline.substring(7).trim();
+					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);
+					    	modelmaterials.get(modelmaterials.size()-1).filename = farg;
+					    	modelmaterials.get(modelmaterials.size()-1).roughnessfileimage = UtilLib.loadImage(loadimgfile.getPath(), loadresourcefromjar);
+					    }else if (fline.toLowerCase().startsWith("map_pm ")) {
+					    	String farg = fline.substring(7).trim();
+					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);
+					    	modelmaterials.get(modelmaterials.size()-1).filename = farg;
+					    	modelmaterials.get(modelmaterials.size()-1).metallicfileimage = UtilLib.loadImage(loadimgfile.getPath(), loadresourcefromjar);
+					    }else if (fline.toLowerCase().startsWith("map_ps ")) {
+					    	String farg = fline.substring(7).trim();
+					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);
+					    	modelmaterials.get(modelmaterials.size()-1).filename = farg;
+					    	modelmaterials.get(modelmaterials.size()-1).sheenfileimage = UtilLib.loadImage(loadimgfile.getPath(), loadresourcefromjar);
 					    }else if (fline.toLowerCase().startsWith("map_ns ")) {
 					    	String farg = fline.substring(7).trim();
 					    	File loadimgfile = new File(loadmtlfile.getParent(),farg);

--- a/src/fi/jkauppa/javarenderengine/RenderLib.java
+++ b/src/fi/jkauppa/javarenderengine/RenderLib.java
@@ -337,6 +337,13 @@ public class RenderLib {
 									copymaterial.snapimage = copymaterial.fileimage.getSnapshot();
 									tritextureimage = copymaterial.snapimage;
 								}
+								Color emissivecolor = copymaterial.emissivecolor;
+								VolatileImage emissivetexture = copymaterial.emissivefileimage;
+								BufferedImage emissivetextureimage = copymaterial.emissivesnapimage;
+								if ((emissivetexture!=null)&&(emissivetextureimage==null)) {
+									copymaterial.emissivesnapimage = copymaterial.emissivefileimage.getSnapshot();
+									emissivetextureimage = copymaterial.emissivesnapimage;
+								}
 								for (int j=jstart;j<=jend;j++) {
 									Line drawline = vertplanetriangleint[j-jstart][0];
 									if (drawline!=null) {
@@ -366,7 +373,7 @@ public class RenderLib {
 											double[] vpixelpoint1angled = MathLib.vectorAngle(vpixelpointdir1invd, vpixelpointdir12d);
 											double vpixelyangsort1 = vpixelyangs[vpixelyinds[0]]; 
 											int vpixelyind1 = (int)Math.ceil(vpixelysort[0]); 
-											int vpixelyind2 = (int)Math.floor(vpixelysort[1]); 
+											int vpixelyind2 = (int)Math.floor(vpixelysort[1]);
 											int vpixelystart = vpixelyind1;
 											int vpixelyend = vpixelyind2;
 											Direction[] vpixelpointdir12 = MathLib.vectorFromPoints(vpixelpoint1, vpixelpoint2);
@@ -412,6 +419,11 @@ public class RenderLib {
 																Color texcolorshade = new Color(texcolorcomp[0], texcolorcomp[1], texcolorcomp[2], alphacolor);
 																if (!unlit) {
 																	texcolorshade = new Color(texcolorcomp[0]*shadingmultiplier, texcolorcomp[1]*shadingmultiplier, texcolorcomp[2]*shadingmultiplier, alphacolor);
+																} else {
+																	texcolorshade = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+																	if (emissivetexture!=null) {
+																		texcolorshade = new Color(emissivetextureimage.getRGB(lineuvx, lineuvy));
+																	}
 																}
 																g2.setColor(texcolorshade);
 																g2.drawLine(j, n, j, n);
@@ -419,6 +431,11 @@ public class RenderLib {
 														} else {
 															if (!unlit) {
 																trianglecolor = new Color(tricolorcomp[0]*shadingmultiplier, tricolorcomp[1]*shadingmultiplier, tricolorcomp[2]*shadingmultiplier, alphacolor);
+															} else {
+																trianglecolor = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+																if (emissivecolor!=null) {
+																	trianglecolor = emissivecolor; 
+																}
 															}
 															g2.setColor(trianglecolor);
 															g2.drawLine(j, n, j, n);
@@ -526,6 +543,13 @@ public class RenderLib {
 									copymaterial.snapimage = copymaterial.fileimage.getSnapshot();
 									tritextureimage = copymaterial.snapimage;
 								}
+								Color emissivecolor = copymaterial.emissivecolor;
+								VolatileImage emissivetexture = copymaterial.emissivefileimage;
+								BufferedImage emissivetextureimage = copymaterial.emissivesnapimage;
+								if ((emissivetexture!=null)&&(emissivetextureimage==null)) {
+									copymaterial.emissivesnapimage = copymaterial.emissivefileimage.getSnapshot();
+									emissivetextureimage = copymaterial.emissivesnapimage;
+								}
 								for (int j=jstart;j<=jend;j++) {
 									Line drawline = vertplanetriangleint[j-jstart][0];
 									if (drawline!=null) {
@@ -603,6 +627,11 @@ public class RenderLib {
 																Color texcolorshade = new Color(texcolorcomp[0], texcolorcomp[1], texcolorcomp[2], alphacolor);
 																if (!unlit) {
 																	texcolorshade = new Color(texcolorcomp[0]*shadingmultiplier, texcolorcomp[1]*shadingmultiplier, texcolorcomp[2]*shadingmultiplier, alphacolor);
+																} else {
+																	texcolorshade = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+																	if (emissivetexture!=null) {
+																		texcolorshade = new Color(emissivetextureimage.getRGB(lineuvx, lineuvy));
+																	}
 																}
 																g2.setColor(texcolorshade);
 																g2.drawLine(j, n, j, n);
@@ -610,6 +639,11 @@ public class RenderLib {
 														} else {
 															if (!unlit) {
 																trianglecolor = new Color(tricolorcomp[0]*shadingmultiplier, tricolorcomp[1]*shadingmultiplier, tricolorcomp[2]*shadingmultiplier, alphacolor);
+															} else {
+																trianglecolor = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+																if (emissivecolor!=null) {
+																	trianglecolor = emissivecolor; 
+																}
 															}
 															g2.setColor(trianglecolor);
 															g2.drawLine(j, n, j, n);
@@ -765,6 +799,13 @@ public class RenderLib {
 									copymaterial.snapimage = copymaterial.fileimage.getSnapshot();
 									tritextureimage = copymaterial.snapimage;
 								}
+								Color emissivecolor = copymaterial.emissivecolor;
+								VolatileImage emissivetexture = copymaterial.emissivefileimage;
+								BufferedImage emissivetextureimage = copymaterial.emissivesnapimage;
+								if ((emissivetexture!=null)&&(emissivetextureimage==null)) {
+									copymaterial.emissivesnapimage = copymaterial.emissivefileimage.getSnapshot();
+									emissivetextureimage = copymaterial.emissivesnapimage;
+								}
 								int jstart = copytrianglelistint[it].y;
 								int jend = copytrianglelistint[it].y+copytrianglelistint[it].height-1;
 								int istart = copytrianglelistint[it].x;
@@ -803,6 +844,11 @@ public class RenderLib {
 														Color texcolorshade = new Color(texcolorcomp[0], texcolorcomp[1], texcolorcomp[2], alphacolor);
 														if (!unlit) {
 															texcolorshade = new Color(texcolorcomp[0]*shadingmultiplier, texcolorcomp[1]*shadingmultiplier, texcolorcomp[2]*shadingmultiplier, alphacolor);
+														} else {
+															texcolorshade = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+															if (emissivetexture!=null) {
+																texcolorshade = new Color(emissivetextureimage.getRGB(lineuvx, lineuvy));
+															}
 														}
 														g2.setColor(texcolorshade);
 														g2.drawLine(i, j, i, j);
@@ -810,6 +856,11 @@ public class RenderLib {
 												} else {
 													if (!unlit) {
 														trianglecolor = new Color(tricolorcomp[0]*shadingmultiplier, tricolorcomp[1]*shadingmultiplier, tricolorcomp[2]*shadingmultiplier, alphacolor);
+													} else {
+														trianglecolor = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+														if (emissivecolor!=null) {
+															trianglecolor = emissivecolor; 
+														}
 													}
 													g2.setColor(trianglecolor);
 													g2.drawLine(i, j, i, j);
@@ -902,6 +953,13 @@ public class RenderLib {
 									copymaterial.snapimage = copymaterial.fileimage.getSnapshot();
 									tritextureimage = copymaterial.snapimage;
 								}
+								Color emissivecolor = copymaterial.emissivecolor;
+								VolatileImage emissivetexture = copymaterial.emissivefileimage;
+								BufferedImage emissivetextureimage = copymaterial.emissivesnapimage;
+								if ((emissivetexture!=null)&&(emissivetextureimage==null)) {
+									copymaterial.emissivesnapimage = copymaterial.emissivefileimage.getSnapshot();
+									emissivetextureimage = copymaterial.emissivesnapimage;
+								}
 								int jstart = copytrianglelistint[it].y;
 								int jend = copytrianglelistint[it].y+copytrianglelistint[it].height-1;
 								int istart = copytrianglelistint[it].x;
@@ -940,6 +998,11 @@ public class RenderLib {
 														Color texcolorshade = new Color(texcolorcomp[0], texcolorcomp[1], texcolorcomp[2], alphacolor);
 														if (!unlit) {
 															texcolorshade = new Color(texcolorcomp[0]*shadingmultiplier, texcolorcomp[1]*shadingmultiplier, texcolorcomp[2]*shadingmultiplier, alphacolor);
+														} else {
+															texcolorshade = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+															if (emissivetexture!=null) {
+																texcolorshade = new Color(emissivetextureimage.getRGB(lineuvx, lineuvy));
+															}
 														}
 														g2.setColor(texcolorshade);
 														g2.drawLine(i, j, i, j);
@@ -947,6 +1010,11 @@ public class RenderLib {
 												} else {
 													if (!unlit) {
 														trianglecolor = new Color(tricolorcomp[0]*shadingmultiplier, tricolorcomp[1]*shadingmultiplier, tricolorcomp[2]*shadingmultiplier, alphacolor);
+													} else {
+														trianglecolor = new Color(0.0f, 0.0f, 0.0f, alphacolor);
+														if (emissivecolor!=null) {
+															trianglecolor = emissivecolor; 
+														}
 													}
 													g2.setColor(trianglecolor);
 													g2.drawLine(i, j, i, j);


### PR DESCRIPTION
Changed unlit mode to draw only emissive triangle surfaces to later add multi-pass surface lightmap accumulation in renderView functions in RenderLib.
Added emissive, roughness, metallic and sheen texture images handling in saveWaveFrontOBJFile and loadWaveFrontOBJFile functions in ModelLib.