### PR TITLE
Updated CADApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ CTRL-V            -- paste image from clipboard
 CAD App Keys:
 ENTER             -- changes between polygon flat/textured/none fill modes (looping)
 SHIFT-ENTER       -- changes between unlit and lit render modes (looping)
+CTRL-ENTER        -- re-calculates all entity triangle surface light maps
 WASD              -- camera location change up/left/down/right (minmax)
 C-SPACE           -- camera location change backward/forward (minmax)
 QE                -- camera tilt change left/right (looping)
 BACKSPACE         -- removes all vector lines
 SHIFT-BACKSPACE   -- reset camera to starting location
+CTRL-BACKSPACE    -- reset all entity triangle surface light maps to zero
 DRAG-LMB          -- material drag triangle paint
 SHIFT-LMB         -- material picker at cursor
 CTRL-DRAG-LMB     -- move line vertex

--- a/src/fi/jkauppa/javarenderengine/CADApp.java
+++ b/src/fi/jkauppa/javarenderengine/CADApp.java
@@ -108,6 +108,7 @@ public class CADApp extends AppHandlerPanel {
 		this.imagechooser.addChoosableFileFilter(this.wbmpfilefilter);
 		this.imagechooser.setFileFilter(this.pngfilefilter);
 		this.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+		this.setFocusTraversalKeysEnabled(false);
 	}
 	@Override public void paintComponent(Graphics g) {
 		super.paintComponent(g);
@@ -244,72 +245,117 @@ public class CADApp extends AppHandlerPanel {
 	}
 	@Override public void keyPressed(KeyEvent e) {
 		if (e.getKeyCode()==KeyEvent.VK_BACK_SPACE) {
-			if (!e.isShiftDown()) {
-				this.linelisttree.clear();
-				this.entitylist = null;
+			if (e.isControlDown()) {
+				if (this.entitylist!=null) {
+					for (int j=0;j<this.entitylist.length;j++) {
+						if (this.entitylist[j].trianglelist!=null) {
+							for (int i=0;i<this.entitylist[j].trianglelist.length;i++) {
+								if (this.entitylist[j].trianglelist[i].mat!=null) {
+									this.entitylist[j].trianglelist[i].mat = this.entitylist[j].trianglelist[i].mat.copy();
+									this.entitylist[j].trianglelist[i].mat.ambientcolor = null;
+									this.entitylist[j].trianglelist[i].mat.ambientfileimage = null;
+									this.entitylist[j].trianglelist[i].mat.ambientsnapimage = null;
+								}
+							}
+						}
+					}
+				}
+			} else {
+				if (!e.isShiftDown()) {
+					this.linelisttree.clear();
+					this.entitylist = null;
+				}
+				this.editpos = new Position(0.0f, 0.0f, 0.0f);
+				this.campos = new Position(0.0f,0.0f,this.editplanedistance);
+				this.camrot = new Rotation(0.0f, 0.0f, 0.0f);
+				updateCameraDirections();
 			}
-			this.editpos = new Position(0.0f, 0.0f, 0.0f);
-			this.campos = new Position(0.0f,0.0f,this.editplanedistance);
-			this.camrot = new Rotation(0.0f, 0.0f, 0.0f);
-			updateCameraDirections();
 		} else if (e.getKeyCode()==KeyEvent.VK_INSERT) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[0] += 0.01f; if (drawcolorhsb[0]>1.0f) {drawcolorhsb[0] = 0.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_DELETE) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[0] -= 0.01f; if (drawcolorhsb[0]<0.0f) {drawcolorhsb[0] = 1.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_HOME) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[1] += 0.01f; if (drawcolorhsb[1]>1.0f) {drawcolorhsb[1] = 1.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_END) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[1] -= 0.01f; if (drawcolorhsb[1]<0.0f) {drawcolorhsb[1] = 0.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_PAGE_UP) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[2] += 0.01f; if (drawcolorhsb[2]>1.0f) {drawcolorhsb[2] = 1.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_PAGE_DOWN) {
 			float[] drawcolorhsb = Color.RGBtoHSB(this.drawmat.facecolor.getRed(), this.drawmat.facecolor.getGreen(), this.drawmat.facecolor.getBlue(), new float[3]);
 			drawcolorhsb[2] -= 0.01f; if (drawcolorhsb[2]<0.0f) {drawcolorhsb[2] = 0.0f;}
 			Color hsbcolor = Color.getHSBColor(drawcolorhsb[0], drawcolorhsb[1], drawcolorhsb[2]);
 			float[] colorvalues = hsbcolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],this.drawmat.transparency);
-			this.drawmat = new Material(newfacecolor,this.drawmat.transparency,null);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.fileimage = null;
+			this.drawmat.snapimage = null;
 		} else if (e.getKeyCode()==KeyEvent.VK_MULTIPLY) {
-			float newemissivity = this.drawmat.emissivity+0.01f; if (newemissivity>1.0f) {newemissivity = 1.0f;}
+			float newemissivity = this.drawmat.emissivity*1.1f; if (newemissivity<=0.0f) {newemissivity = 0.00001f;} if (newemissivity>1.0f) {newemissivity = 1.0f;}
+			float[] drawcolorcomp = this.drawmat.facecolor.getRGBComponents(new float[4]);
+			this.drawmat = this.drawmat.copy();
 			this.drawmat.emissivity = newemissivity;
+			this.drawmat.emissivecolor = new Color(drawcolorcomp[0]*newemissivity,drawcolorcomp[1]*newemissivity,drawcolorcomp[2]*newemissivity,1.0f);
 		} else if (e.getKeyCode()==KeyEvent.VK_DIVIDE) {
-			float newemissivity = this.drawmat.emissivity-0.01f; if (newemissivity<0.0f) {newemissivity = 0.0f;}
+			float newemissivity = this.drawmat.emissivity/1.1f;
+			float[] drawcolorcomp = this.drawmat.facecolor.getRGBComponents(new float[4]);
+			this.drawmat = new Material(this.drawmat.facecolor,this.drawmat.transparency,this.drawmat.fileimage);
 			this.drawmat.emissivity = newemissivity;
+			this.drawmat.emissivecolor = new Color(drawcolorcomp[0]*newemissivity,drawcolorcomp[1]*newemissivity,drawcolorcomp[2]*newemissivity,1.0f);
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD9) {
 			float newtransparency = this.drawmat.transparency+0.01f; if (newtransparency>1.0f) {newtransparency = 1.0f;}
 			float[] colorvalues = this.drawmat.facecolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],newtransparency);
-			this.drawmat = new Material(newfacecolor,newtransparency,this.drawmat.fileimage);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.transparency = newtransparency;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD8) {
 			float newtransparency = this.drawmat.transparency-0.01f; if (newtransparency<0.0f) {newtransparency = 0.0f;}
 			float[] colorvalues = this.drawmat.facecolor.getRGBColorComponents(new float[3]);
 			Color newfacecolor = new Color(colorvalues[0],colorvalues[1],colorvalues[2],newtransparency);
-			this.drawmat = new Material(newfacecolor,newtransparency,this.drawmat.fileimage);
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.facecolor = newfacecolor;
+			this.drawmat.transparency = newtransparency;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD7) {
 			if ((this.mouseovertriangle!=null)&&(this.mouseovertriangle.length>0)) {
 				Triangle[] stri = {this.mouseovertriangle[this.mouseovertriangle.length-1]};
@@ -323,10 +369,12 @@ public class CADApp extends AppHandlerPanel {
 			}
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD6) {
 			float newroughness = this.drawmat.roughness+0.01f; if (newroughness>1.0f) {newroughness = 1.0f;}
-			this.drawmat.roughness= newroughness;
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.roughness = newroughness;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD5) {
 			float newroughness = this.drawmat.roughness-0.01f; if (newroughness<0.0f) {newroughness = 0.0f;}
-			this.drawmat.roughness= newroughness;
+			this.drawmat = this.drawmat.copy();
+			this.drawmat.roughness = newroughness;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD4) {
 			if ((this.mouseovertriangle!=null)&&(this.mouseovertriangle.length>0)) {
 				Triangle[] stri = {this.mouseovertriangle[this.mouseovertriangle.length-1]};
@@ -334,9 +382,11 @@ public class CADApp extends AppHandlerPanel {
 			}
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD3) {
 			float newmetallic = this.drawmat.metallic+0.01f; if (newmetallic>1.0f) {newmetallic = 1.0f;}
+			this.drawmat = this.drawmat.copy();
 			this.drawmat.metallic = newmetallic;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD2) {
 			float newmetallic = this.drawmat.metallic-0.01f; if (newmetallic<0.0f) {newmetallic = 0.0f;}
+			this.drawmat = this.drawmat.copy();
 			this.drawmat.metallic = newmetallic;
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD1) {
 	    	Triangle mousetriangle = null;
@@ -383,9 +433,13 @@ public class CADApp extends AppHandlerPanel {
 			}
 		} else if (e.getKeyCode()==KeyEvent.VK_NUMPAD0) {
 			(new EntityListUpdater()).start();
+		} else if (e.getKeyCode()==KeyEvent.VK_TAB) {
+			//TODO <tbd>
 		} else if (e.getKeyCode()==KeyEvent.VK_ENTER) {
 			if (e.isShiftDown()) {
 				this.unlitrender = !this.unlitrender;
+			} else if (e.isControlDown()) {
+		    	(new EntityLightMapUpdater()).start();
 			} else {
 				this.polygonfillmode += 1;
 				if (this.polygonfillmode>3) {
@@ -1106,6 +1160,21 @@ public class CADApp extends AppHandlerPanel {
 					CADApp.this.mouseovertriangle = CADApp.this.softwarerenderview.mouseovertriangle;
 				}
 				SoftwareRenderViewUpdater.renderupdaterrunning = false;
+			}
+		}
+	}
+
+	private class EntityLightMapUpdater extends Thread {
+		private static boolean entitylightmapupdaterrunning = false;
+		public void run() {
+			if (!EntityLightMapUpdater.entitylightmapupdaterrunning) {
+				EntityLightMapUpdater.entitylightmapupdaterrunning = true;
+				if (CADApp.this.polygonfillmode==2) {
+					RenderLib.renderSurfaceFaceCubemapPlaneViewHardware(CADApp.this.entitylist, 32, 1);
+				} else if (CADApp.this.polygonfillmode==3) {
+					RenderLib.renderSurfaceFaceCubemapPlaneViewSoftware(CADApp.this.entitylist, 32, 1);
+				}
+				EntityLightMapUpdater.entitylightmapupdaterrunning = false;
 			}
 		}
 	}

--- a/src/fi/jkauppa/javarenderengine/DrawApp.java
+++ b/src/fi/jkauppa/javarenderengine/DrawApp.java
@@ -78,6 +78,7 @@ public class DrawApp extends AppHandlerPanel {
 		this.filechooser.addChoosableFileFilter(this.wbmpfilefilter);
 		this.filechooser.setFileFilter(this.pngfilefilter);
 		this.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+		this.setFocusTraversalKeysEnabled(false);
 	}
 	
 	@Override public void paintComponent(Graphics g) {

--- a/src/fi/jkauppa/javarenderengine/MathLib.java
+++ b/src/fi/jkauppa/javarenderengine/MathLib.java
@@ -1766,5 +1766,13 @@ public class MathLib {
 		Direction[]  k = null;
 		return k;
 	}
+	public static Plane[] surfaceMirrorPlanes(Plane[] vsurf, Plane[] vplane, double refraction) {
+		Plane[]  k = null;
+		return k;
+	}
+	public static Plane[] surfaceRefractionPlanes(Plane[] vsurf, Plane[] vplane, double refraction) {
+		Plane[]  k = null;
+		return k;
+	}
 	
 }

--- a/src/fi/jkauppa/javarenderengine/ModelApp.java
+++ b/src/fi/jkauppa/javarenderengine/ModelApp.java
@@ -66,6 +66,7 @@ public class ModelApp extends AppHandlerPanel {
 		this.filechooser.setFileFilter(this.objfilefilter);
 		this.filechooser.setAcceptAllFileFilterUsed(false);
 		this.setCursor(this.customcursor);
+		this.setFocusTraversalKeysEnabled(false);
 	}
 
 	@Override public void paintComponent(Graphics g) {

--- a/src/fi/jkauppa/javarenderengine/ModelLib.java
+++ b/src/fi/jkauppa/javarenderengine/ModelLib.java
@@ -93,7 +93,51 @@ public class ModelLib {
 			}
 			return k;
 		}
-		public Material copy(){return new Material(this.facecolor,this.transparency,this.fileimage);}
+		public Material copy(){
+			Material k = new Material();
+			k.materialname = this.materialname;
+			k.fileimage = this.fileimage;
+			k.snapimage = this.snapimage;
+			k.ambientfileimage = this.ambientfileimage;
+			k.ambientsnapimage = this.ambientsnapimage;
+			k.specularfileimage = this.specularfileimage;
+			k.specularsnapimage = this.specularsnapimage;
+			k.specularhighfileimage = this.specularhighfileimage;
+			k.specularhighsnapimage = this.specularhighsnapimage;
+			k.emissivefileimage = this.emissivefileimage;
+			k.emissivesnapimage = this.emissivesnapimage;
+			k.alphafileimage = this.alphafileimage;
+			k.alphasnapimage = this.alphasnapimage;
+			k.roughnessfileimage = this.roughnessfileimage;
+			k.roughnesssnapimage = this.roughnesssnapimage;
+			k.metallicfileimage = this.metallicfileimage;
+			k.metallicsnapimage = this.metallicsnapimage;
+			k.sheenfileimage = this.sheenfileimage;
+			k.sheensnapimage = this.sheensnapimage;
+			k.bumpfileimage = this.bumpfileimage;
+			k.bumpsnapimage = this.bumpsnapimage;
+			k.dispfileimage = this.dispfileimage;
+			k.dispsnapimage = this.dispsnapimage;
+			k.decalfileimage = this.decalfileimage;
+			k.decalsnapimage = this.decalsnapimage;
+			k.filename = this.filename;
+			k.facecolor = this.facecolor;
+			k.ambientcolor = this.ambientcolor;
+			k.specularcolor = this.specularcolor;
+			k.emissivecolor = this.emissivecolor;
+			k.specularexp = this.specularexp;
+			k.emissivity = this.emissivity;
+			k.transparency = this.transparency;
+			k.roughness = this.roughness;
+			k.metallic = this.metallic;
+			k.sheen = this.sheen;
+			k.coatthickness = this.coatthickness;
+			k.coatroughtness = this.coatroughtness;
+			k.anisotropy = this.anisotropy;
+			k.anisotropyrot = this.anisotropyrot;
+			k.refraction = this.refraction;
+			return k;
+		}
 	}
 
 	public static class RenderView {
@@ -453,7 +497,7 @@ public class ModelLib {
 			}
 			return k;
 		}
-		public Triangle copy(){Triangle k=new Triangle(this.pos1.copy(),this.pos2.copy(),this.pos3.copy());k.norm=this.norm;k.mat=this.mat;k.ind=this.ind;return k;}
+		public Triangle copy(){Triangle k=new Triangle(this.pos1.copy(),this.pos2.copy(),this.pos3.copy());k.norm=this.norm;k.mat=this.mat;k.lmatl=this.lmatl;k.ind=this.ind;return k;}
 	}
 	public static class Entity implements Comparable<Entity> {
 		public Entity[] childlist = null;

--- a/src/fi/jkauppa/javarenderengine/RenderLib.java
+++ b/src/fi/jkauppa/javarenderengine/RenderLib.java
@@ -1377,6 +1377,13 @@ public class RenderLib {
 								float p4pixelr = 0.0f;
 								float p4pixelg = 0.0f;
 								float p4pixelb = 0.0f;
+								float pixelcount = 6*rendersize*rendersize;
+								if (entitylist[j].trianglelist[i].mat.emissivecolor!=null) {
+									float[] triangleemissivecolorcomp = entitylist[j].trianglelist[i].mat.emissivecolor.getRGBComponents(new float[4]);
+									p4pixelr = triangleemissivecolorcomp[0]*pixelcount;
+									p4pixelg = triangleemissivecolorcomp[1]*pixelcount;
+									p4pixelb = triangleemissivecolorcomp[2]*pixelcount;
+								}
 								for (int k=0;k<cubemapviews.length;k++) {
 									for (int ky=0;ky<cubemapviews[k].snapimage.getHeight();ky++) {
 										for (int kx=0;kx<cubemapviews[k].snapimage.getWidth();kx++) {
@@ -1388,7 +1395,6 @@ public class RenderLib {
 										}
 									}
 								}
-								float pixelcount = 6*rendersize*rendersize;
 								float p4pixelrt = multiplier*p4pixelr/pixelcount;
 								float p4pixelgt = multiplier*p4pixelg/pixelcount;
 								float p4pixelbt = multiplier*p4pixelb/pixelcount;
@@ -1450,6 +1456,13 @@ public class RenderLib {
 								float p4pixelr = 0.0f;
 								float p4pixelg = 0.0f;
 								float p4pixelb = 0.0f;
+								float pixelcount = 6*rendersize*rendersize;
+								if (entitylist[j].trianglelist[i].mat.emissivecolor!=null) {
+									float[] triangleemissivecolorcomp = entitylist[j].trianglelist[i].mat.emissivecolor.getRGBComponents(new float[4]);
+									p4pixelr = triangleemissivecolorcomp[0]*pixelcount;
+									p4pixelg = triangleemissivecolorcomp[1]*pixelcount;
+									p4pixelb = triangleemissivecolorcomp[2]*pixelcount;
+								}
 								for (int k=0;k<cubemapviews.length;k++) {
 									for (int ky=0;ky<cubemapviews[k].snapimage.getHeight();ky++) {
 										for (int kx=0;kx<cubemapviews[k].snapimage.getWidth();kx++) {
@@ -1461,7 +1474,6 @@ public class RenderLib {
 										}
 									}
 								}
-								float pixelcount = 6*rendersize*rendersize;
 								float p4pixelrt = multiplier*p4pixelr/pixelcount;
 								float p4pixelgt = multiplier*p4pixelg/pixelcount;
 								float p4pixelbt = multiplier*p4pixelb/pixelcount;
@@ -1523,6 +1535,13 @@ public class RenderLib {
 								float p4pixelr = 0.0f;
 								float p4pixelg = 0.0f;
 								float p4pixelb = 0.0f;
+								float pixelcount = 6*rendersize*rendersize;
+								if (entitylist[j].trianglelist[i].mat.emissivecolor!=null) {
+									float[] triangleemissivecolorcomp = entitylist[j].trianglelist[i].mat.emissivecolor.getRGBComponents(new float[4]);
+									p4pixelr = triangleemissivecolorcomp[0]*pixelcount;
+									p4pixelg = triangleemissivecolorcomp[1]*pixelcount;
+									p4pixelb = triangleemissivecolorcomp[2]*pixelcount;
+								}
 								for (int k=0;k<cubemapviews.length;k++) {
 									for (int ky=0;ky<cubemapviews[k].snapimage.getHeight();ky++) {
 										for (int kx=0;kx<cubemapviews[k].snapimage.getWidth();kx++) {
@@ -1534,7 +1553,6 @@ public class RenderLib {
 										}
 									}
 								}
-								float pixelcount = 6*rendersize*rendersize;
 								float p4pixelrt = multiplier*p4pixelr/pixelcount;
 								float p4pixelgt = multiplier*p4pixelg/pixelcount;
 								float p4pixelbt = multiplier*p4pixelb/pixelcount;
@@ -1597,6 +1615,13 @@ public class RenderLib {
 								float p4pixelr = 0.0f;
 								float p4pixelg = 0.0f;
 								float p4pixelb = 0.0f;
+								float pixelcount = 6*rendersize*rendersize;
+								if (entitylist[j].trianglelist[i].mat.emissivecolor!=null) {
+									float[] triangleemissivecolorcomp = entitylist[j].trianglelist[i].mat.emissivecolor.getRGBComponents(new float[4]);
+									p4pixelr = triangleemissivecolorcomp[0]*pixelcount;
+									p4pixelg = triangleemissivecolorcomp[1]*pixelcount;
+									p4pixelb = triangleemissivecolorcomp[2]*pixelcount;
+								}
 								for (int k=0;k<cubemapviews.length;k++) {
 									for (int ky=0;ky<cubemapviews[k].snapimage.getHeight();ky++) {
 										for (int kx=0;kx<cubemapviews[k].snapimage.getWidth();kx++) {
@@ -1608,7 +1633,6 @@ public class RenderLib {
 										}
 									}
 								}
-								float pixelcount = 6*rendersize*rendersize;
 								float p4pixelrt = multiplier*p4pixelr/pixelcount;
 								float p4pixelgt = multiplier*p4pixelg/pixelcount;
 								float p4pixelbt = multiplier*p4pixelb/pixelcount;


### PR DESCRIPTION
Added key binding CTRL-ENTER to run EntityLightMapUpdater thread and CTRL-BACKSPACE to reset all entity triangle light maps in CADApp.
Updated to proper handling of material parameters retaining material values including emissivity as copy in CADApp.
Fixed renderSurface functions triangle surfaces not self-lighting with emissive color in RenderLib.