### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -61,7 +61,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.3.2");
+		this.setTitle("Java Render Engine v2.3.3");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {

--- a/src/fi/jkauppa/javarenderengine/MathLib.java
+++ b/src/fi/jkauppa/javarenderengine/MathLib.java
@@ -1293,6 +1293,14 @@ public class MathLib {
 		for (int i=0;i<vres;i++){k[i]=-halfvfov+vstep*i;}
 		return k;
 	}
+	public static Direction[] spheremapPlaneVectors(Position vpos, int vhres, Matrix vmat) {
+		Direction[] vupdir = {new Direction(0.0f,-1.0f,0.0f)};
+		Direction[] vupdirrot = matrixMultiply(vupdir, vmat);
+		Plane[] spheremapplanes = spheremapPlanes(vpos, vhres, vmat);
+		Direction[] planenormals = planeNormals(spheremapplanes);
+		Direction[] spheremapforwardvectors = vectorCross(vupdirrot[0], planenormals);
+		return normalizeVector(spheremapforwardvectors);
+	}
 	public static Plane[] spheremapPlanes(Position vpos, int vhres, Matrix vmat) {
 		double[] hangles  = spheremapAngles(vhres, 360.0f);
 		Direction[] smvecs = new Direction[vhres];

--- a/src/fi/jkauppa/javarenderengine/ModelLib.java
+++ b/src/fi/jkauppa/javarenderengine/ModelLib.java
@@ -165,6 +165,7 @@ public class ModelLib {
 		public Direction[] dirs;
 		public Direction[][] rays;
 		public Plane[] planes;
+		public Direction[] fwddirs;
 	}
 	
 	public static class Cubemap {


### PR DESCRIPTION
Updated all Ray renderView functions to not clip triangles if they are partially behind the camera forward plane.
Updated all renderSpheremapView functions to use proper forward vector for the render pixel width column.
Note: Removed MathLib sphere/triangle projection intersection functions from all renderView functions which do not yet support partially behind forward plane triangles.