### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -61,7 +61,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.3.14");
+		this.setTitle("Java Render Engine v2.3.15");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {

--- a/src/fi/jkauppa/javarenderengine/RenderLib.java
+++ b/src/fi/jkauppa/javarenderengine/RenderLib.java
@@ -933,7 +933,7 @@ public class RenderLib {
 		triangleviewangle[0] -= 90.0f;
 		boolean frontsidevisible = true;
 		if (triangleviewangle[0]<0.0f) {triangleviewangle[0]=0.0f;frontsidevisible=false;}
-		float shadingmultiplier = ((((float)triangleviewangle[0])/1.5f)+30.0f)/90.0f;
+		float shadingmultiplier = ((float)triangleviewangle[0])/90.0f;
 		if (texuv!=null) {
 			if (lightmaptexture!=null) {
 				lightmapcolor = null;
@@ -968,23 +968,20 @@ public class RenderLib {
 			}
 		}
 		if (trianglecolor!=null) {
-			float texr = trianglecolorcomp[0];
-			float texg = trianglecolorcomp[1];
-			float texb = trianglecolorcomp[2];
+			float texr = trianglecolorcomp[0]*shadingmultiplier;
+			float texg = trianglecolorcomp[1]*shadingmultiplier;
+			float texb = trianglecolorcomp[2]*shadingmultiplier;
 			float multiplier = 10.0f;
-			if (!unlit) {
-				texr *= shadingmultiplier;
-				texg *= shadingmultiplier;
-				texb *= shadingmultiplier;
-			}
-			if ((frontsidevisible)&&(lightmapcolor!=null)) {
-				texr *= lightmapcolorcomp[0]*multiplier;
-				texg *= lightmapcolorcomp[1]*multiplier;
-				texb *= lightmapcolorcomp[2]*multiplier;
-			} else if (unlit) {
-				texr = 0.0f;
-				texg = 0.0f;
-				texb = 0.0f;
+			if (unlit) {
+				if ((frontsidevisible)&&(lightmapcolor!=null)) {
+					texr *= lightmapcolorcomp[0]*multiplier;
+					texg *= lightmapcolorcomp[1]*multiplier;
+					texb *= lightmapcolorcomp[2]*multiplier;
+				} else {
+					texr = 0.0f;
+					texg = 0.0f;
+					texb = 0.0f;
+				}
 			}
 			if ((frontsidevisible)&&(emissivecolor!=null)) {
 				texr += emissivecolorcomp[0]*multiplier;


### PR DESCRIPTION
Updated trianglePixelShader function to display all render modes with camera ray surface angle based shading multiplier in range of 0-1 where 0 is when single sided triangle is viewed from backside or double sided triangle is viewed from 90 degrees angle.
Updated trianglePixelShader function in unlit render mode to always apply lightmap illumination/none to triangle surface texture color, and lit render mode to not apply any calculated lighting to triangle surfaces displaying triangle surface/emissive colors only.