### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/CADApp.java
+++ b/src/fi/jkauppa/javarenderengine/CADApp.java
@@ -816,8 +816,8 @@ public class CADApp extends AppHandlerPanel {
     		double mouserelativelocationx = this.mouselocationx-this.origindeltax;
     		double mouserelativelocationy = this.mouselocationy-this.origindeltay;
 			if (this.snaplinemode) {
-	    		mouserelativelocationx = UtilLib.snapToGrid(this.mouselocationx-this.origindeltax,this.gridstep);
-	    		mouserelativelocationy = UtilLib.snapToGrid(this.mouselocationy-this.origindeltay,this.gridstep);
+	    		mouserelativelocationx = MathLib.snapToGrid(this.mouselocationx-this.origindeltax,this.gridstep);
+	    		mouserelativelocationy = MathLib.snapToGrid(this.mouselocationy-this.origindeltay,this.gridstep);
 				if ((this.mouseoververtex!=null)&&(this.mouseoververtex.length>0)) {
 					this.drawstartpos = this.mouseoververtex[this.mouseoververtex.length-1].copy(); 
 				}
@@ -910,8 +910,8 @@ public class CADApp extends AppHandlerPanel {
 	    		double mouserelativelocationx = this.mouselocationx-this.origindeltax;
 	    		double mouserelativelocationy = this.mouselocationy-this.origindeltay;
 				if (this.snaplinemode) {
-		    		mouserelativelocationx = UtilLib.snapToGrid(this.mouselocationx-this.origindeltax,this.gridstep);
-		    		mouserelativelocationy = UtilLib.snapToGrid(this.mouselocationy-this.origindeltay,this.gridstep);
+		    		mouserelativelocationx = MathLib.snapToGrid(this.mouselocationx-this.origindeltax,this.gridstep);
+		    		mouserelativelocationy = MathLib.snapToGrid(this.mouselocationy-this.origindeltay,this.gridstep);
 					if ((this.mouseoververtex!=null)&&(this.mouseoververtex.length>0)) {
 						drawlocation = this.mouseoververtex[this.mouseoververtex.length-1].copy(); 
 					}
@@ -1230,12 +1230,13 @@ public class CADApp extends AppHandlerPanel {
 		public void run() {
 			if (!EntityLightMapUpdater.entitylightmapupdaterrunning) {
 				EntityLightMapUpdater.entitylightmapupdaterrunning = true;
+				int bounces = 2;
 				if (CADApp.this.polygonfillmode==1) {
-					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, 2, 3);
+					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, bounces, 3);
 				} else if (CADApp.this.polygonfillmode==2) {
-					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, 2, 1);
+					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, bounces, 1);
 				} else if (CADApp.this.polygonfillmode==3) {
-					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, 2, 2);
+					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, bounces, 2);
 				}
 				EntityLightMapUpdater.entitylightmapupdaterrunning = false;
 			}

--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -62,7 +62,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.3.31");
+		this.setTitle("Java Render Engine v2.3.32");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {
@@ -420,6 +420,10 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 		Direction[] rrintvdir2 = {new Direction(0,1,0), new Direction(0,1,1)};
 		Position[][] rrint = MathLib.rayRayIntersection(rrintvpos1, rrintvdir1, rrintvpos2, rrintvdir2);
 		for (int j=0;j<rrint.length;j++) {for (int i=0;i<rrint[j].length;i++) { if (rrint[j][i]!=null) {System.out.println("JavaRenderEngine: main: rrint["+j+"]["+i+"]="+rrint[j][i].x+" "+rrint[j][i].y+" "+rrint[j][i].z);} else {System.out.println("JavaRenderEngine: main: rrint["+j+"]["+i+"]=no hit.");}}}
+		Double[] snum = {1.0d, -5.0d, 2.0d, 0.0d, 7.0d};
+		Integer[] snumind = UtilLib.objectIndexSort(snum,null);
+		System.out.print("JavaRenderEngine: main: snumind="); for (int i=0;i<snumind.length;i++) {System.out.print(" "+snumind[i]);}System.out.println();
+		System.out.print("JavaRenderEngine: main: snumval="); for (int i=0;i<snumind.length;i++) {System.out.print(" "+snum[snumind[i]]);}System.out.println();
 		
 		new JavaRenderEngine();
 	}

--- a/src/fi/jkauppa/javarenderengine/MathLib.java
+++ b/src/fi/jkauppa/javarenderengine/MathLib.java
@@ -603,13 +603,10 @@ public class MathLib {
 						}
 						if (ptlhit12&&ptlhit13) {
 							k[n][m] = new Line(ptlint12,ptlint13);
-							k[n][m].ind = 0;
 						} else if (ptlhit12&&ptlhit23) {
 							k[n][m] = new Line(ptlint12,ptlint23);
-							k[n][m].ind = 1;
 						} else if (ptlhit13&&ptlhit23) {
 							k[n][m] = new Line(ptlint13,ptlint23);
-							k[n][m].ind = 2;
 						}
 					}
 				}
@@ -1469,8 +1466,6 @@ public class MathLib {
 					newtriangle1 = new Triangle(newtrianglepoint,vtri[i].pos2,vtri[i].pos1);
 					newtriangle2 = new Triangle(newtrianglepoint,vtri[i].pos3,vtri[i].pos1);
 				}
-				newtriangle1.ind = vtri[i].ind;
-				newtriangle2.ind = vtri[i].ind;
 				newtriangle1.mat = vtri[i].mat;
 				newtriangle2.mat = vtri[i].mat;
 				newtriangle1.norm = vtri[i].norm;
@@ -2250,6 +2245,11 @@ public class MathLib {
 		}
 		return k;
 	}
+	
+	public static int snapToGrid(int coordinate, int gridstep) {
+		return gridstep*(int)Math.round(((double)coordinate)/((double)gridstep));
+	}
+	
 	public static double zeroMod(double val) {
 		return val-Math.floor(val);
 	}
@@ -2281,6 +2281,7 @@ public class MathLib {
 		return k;
 	}
 	public static RenderView[] surfaceMirrorProjectedCamera(Position campos, Plane[] vsurf, Matrix viewrot) {
+		//TODO fix rotationMatrixAroundAxis angle parameter sign
 		RenderView[] k = null;
 		if ((vsurf!=null)&&(campos!=null)) {
 			k = new RenderView[vsurf.length];
@@ -2294,7 +2295,7 @@ public class MathLib {
 			Line[][] ppint = planePlaneIntersection(camrgtplane, vsurf);
 			double[] camrgtvsurfangles = planeAngle(camrgtplane[0], vsurf);
 			for (int i=0;i<vsurf.length;i++) {
-				if ((camfwdvsufrint[0][i]!=null)&&(ppint[0][i]!=null)) {
+				if ((camfwdvsufrint[0][i]!=null)&&(ppint[0][i]!=null)&&(camfwdvsufrint[0][i].isFinite())&&(ppint[0][i].isFinite())) {
 					Line[] ppintline = {ppint[0][i]};
 					Direction[] ppintlinedir = vectorFromPoints(ppintline);
 					double camrgtvsurfangle = camrgtvsurfangles[i];

--- a/src/fi/jkauppa/javarenderengine/ModelApp.java
+++ b/src/fi/jkauppa/javarenderengine/ModelApp.java
@@ -296,7 +296,7 @@ public class ModelApp extends AppHandlerPanel {
 		public void run() {
 			if (!RenderViewUpdater.renderupdaterrunning) {
 				RenderViewUpdater.renderupdaterrunning = true;
-				int bounces = 0;
+				int bounces = 1;
 				if (ModelApp.this.polygonfillmode==1) {
 					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==2) {

--- a/src/fi/jkauppa/javarenderengine/ModelLib.java
+++ b/src/fi/jkauppa/javarenderengine/ModelLib.java
@@ -163,7 +163,6 @@ public class ModelLib {
 		public double hfov=0.0f, vfov=43.0f;
 		public boolean rendered = false;
 		public boolean unlit = false;
-		public int mode = 1;
 		public Direction[] dirs;
 		public Direction[][] rays;
 		public Plane[] planes;
@@ -177,7 +176,7 @@ public class ModelLib {
 		public RenderView sphereview=null;
 	}
 	
-	public static class Position implements Comparable<Position> {public double x,y,z; public Coordinate tex; public Material mat; public int ind=-1; public Position(double xi,double yi,double zi){this.x=xi;this.y=yi;this.z=zi;}
+	public static class Position implements Comparable<Position> {public double x,y,z; public Coordinate tex; public Material mat; public Position(double xi,double yi,double zi){this.x=xi;this.y=yi;this.z=zi;}
 		@Override public int compareTo(Position o){
 			int k = -1;
 			if (this.z>o.z) {
@@ -208,6 +207,7 @@ public class ModelLib {
 		public Position copy(){Position k=new Position(this.x,this.y,this.z); k.tex=this.tex; return k;}
 		public Position invert(){Position k=this.copy(); k.x=-k.x;k.y=-k.y;k.z=-k.z; return k;}
 		public boolean isZero(){return (this.x==0.0f)&&(this.y==0.0f)&&(this.z==0.0f);}
+		public boolean isFinite(){return (Double.isFinite(this.x))&&(Double.isFinite(this.y))&&(Double.isFinite(this.z));}
 	}
 	public static class Direction implements Comparable<Direction> {public double dx,dy,dz; public Direction(double dxi,double dyi,double dzi){this.dx=dxi;this.dy=dyi;this.dz=dzi;}
 		@Override public int compareTo(Direction o){
@@ -240,6 +240,7 @@ public class ModelLib {
 		public Direction copy(){return new Direction(this.dx,this.dy,this.dz);}
 		public Direction invert(){return new Direction(-this.dx,-this.dy,-this.dz);}
 		public boolean isZero(){return (this.dx==0.0f)&&(this.dy==0.0f)&&(this.dz==0.0f);}
+		public boolean isFinite(){return (Double.isFinite(this.dx))&&(Double.isFinite(this.dy))&&(Double.isFinite(this.dz));}
 	}
 	public static class Coordinate implements Comparable<Coordinate> {public double u,v; public Coordinate(double ui,double vi){this.u=ui;this.v=vi;}
 	@Override public int compareTo(Coordinate o){
@@ -268,6 +269,7 @@ public class ModelLib {
 		public Coordinate copy(){return new Coordinate(this.u,this.v);}
 		public Coordinate invert(){return new Coordinate(-this.u,-this.v);}
 		public boolean isZero(){return (this.u==0.0f)&&(this.v==0.0f);}
+		public boolean isFinite(){return (Double.isFinite(this.u))&&(Double.isFinite(this.v));}
 	}
 	public static class Rotation {public double x,y,z; public Rotation(double xi,double yi,double zi){this.x=xi;this.y=yi;this.z=zi;}
 		@Override public boolean equals(Object o) {
@@ -282,7 +284,7 @@ public class ModelLib {
 		}
 		public Rotation copy(){return new Rotation(this.x,this.y,this.z);}
 	}
-	public static class Sphere implements Comparable<Sphere> {public double x,y,z,r; public int ind=-1; public Sphere(double xi,double yi,double zi,double ri){this.x=xi;this.y=yi;this.z=zi;this.r=ri;}
+	public static class Sphere implements Comparable<Sphere> {public double x,y,z,r; public Sphere(double xi,double yi,double zi,double ri){this.x=xi;this.y=yi;this.z=zi;this.r=ri;}
 		@Override public int compareTo(Sphere o) {
 			int k = -1;
 			if (this.z>o.z) {
@@ -314,7 +316,7 @@ public class ModelLib {
 			}
 			return k;
 		}
-		public Sphere copy(){Sphere k = new Sphere(this.x,this.y,this.z,this.r); k.ind=this.ind; return k;}
+		public Sphere copy(){Sphere k = new Sphere(this.x,this.y,this.z,this.r); return k;}
 		public static class SphereDistanceComparator implements Comparator<Sphere> {
 			public Position origin;
 			public SphereDistanceComparator(Position origini) {this.origin = origini;}
@@ -341,8 +343,9 @@ public class ModelLib {
 	public static class Ray {public Position pos; public Direction dir; public Ray(Position posi, Direction diri){this.pos=posi;this.dir=diri;}}
 	public static class Plane {public double a,b,c,d; public Plane(double ai,double bi,double ci,double di){this.a=ai;this.b=bi;this.c=ci;this.d=di;}
 		public Plane invert(){return new Plane(-this.a,-this.b,-this.c,-this.d);}
+		public boolean isFinite(){return (Double.isFinite(this.a))&&(Double.isFinite(this.b))&&(Double.isFinite(this.c))&&(Double.isFinite(this.d));}
 	}
-	public static class Line implements Comparable<Line> {public Position pos1,pos2; public Material mat; public int ind=-1; public Line(Position pos1i,Position pos2i){this.pos1=pos1i;this.pos2=pos2i;}
+	public static class Line implements Comparable<Line> {public Position pos1,pos2; public Material mat; public Line(Position pos1i,Position pos2i){this.pos1=pos1i;this.pos2=pos2i;}
 		@Override public int compareTo(Line o){
 			int k=-1;
 			Line ts=this.sort();
@@ -380,9 +383,10 @@ public class ModelLib {
 			}
 			return k;
 		}
-		public Line copy(){Line k = new Line(new Position(this.pos1.x,this.pos1.y,this.pos1.z),new Position(this.pos2.x,this.pos2.y,this.pos2.z)); k.ind=this.ind; return k;}
+		public Line copy(){Line k = new Line(new Position(this.pos1.x,this.pos1.y,this.pos1.z),new Position(this.pos2.x,this.pos2.y,this.pos2.z)); return k;}
 		public Line swap(){return new Line(this.pos2,this.pos1);}
 		public Line sort(){Line k=this;if (this.pos1.compareTo(this.pos2)==1) {k=this.swap();}return k;}
+		public boolean isFinite(){return (this.pos1!=null)&&(this.pos2!=null)&&(this.pos1.isFinite())&&(this.pos2.isFinite());}
 	}
 	public static class Tetrahedron implements Comparable<Tetrahedron> {public Position pos1,pos2,pos3,pos4; public Tetrahedron(Position pos1i,Position pos2i, Position pos3i,Position pos4i){this.pos1=pos1i;this.pos2=pos2i;this.pos3=pos3i;this.pos4=pos4i;}
 		@Override public int compareTo(Tetrahedron o) {
@@ -450,7 +454,7 @@ public class ModelLib {
 			return k;
 		}
 	}
-	public static class Triangle implements Comparable<Triangle> {public Position pos1,pos2,pos3; public Direction norm; public Material mat = null; public Material[] lmatl = null; public int ind=-1; public Triangle(Position pos1i,Position pos2i,Position pos3i){this.pos1=pos1i;this.pos2=pos2i;this.pos3=pos3i;}
+	public static class Triangle implements Comparable<Triangle> {public Position pos1,pos2,pos3; public Direction norm; public Material mat = null; public Material[] lmatl = null; public Triangle(Position pos1i,Position pos2i,Position pos3i){this.pos1=pos1i;this.pos2=pos2i;this.pos3=pos3i;}
 		@Override public int compareTo(Triangle o) {
 			int k = -1;
 			Position[] tposarray = {this.pos1,this.pos2,this.pos3};
@@ -502,7 +506,7 @@ public class ModelLib {
 			}
 			return k;
 		}
-		public Triangle copy(){Triangle k=new Triangle(this.pos1.copy(),this.pos2.copy(),this.pos3.copy());k.norm=this.norm;k.mat=this.mat;k.lmatl=this.lmatl;k.ind=this.ind;return k;}
+		public Triangle copy(){Triangle k=new Triangle(this.pos1.copy(),this.pos2.copy(),this.pos3.copy());k.norm=this.norm;k.mat=this.mat;k.lmatl=this.lmatl;return k;}
 	}
 	public static class Entity implements Comparable<Entity> {
 		public Entity[] childlist = null;
@@ -514,6 +518,7 @@ public class ModelLib {
 		public Matrix transform = null;
 		public Position translation = null;
 		@Override public int compareTo(Entity o) {return this.sphereboundaryvolume.compareTo(o.sphereboundaryvolume);}
+		public Entity copy(){Entity k=new Entity();k.childlist=this.childlist;k.trianglelist=this.trianglelist;k.linelist=this.linelist;k.vertexlist=this.vertexlist;k.sphereboundaryvolume=this.sphereboundaryvolume;k.aabbboundaryvolume=this.aabbboundaryvolume;k.transform=this.transform;k.translation=this.translation;return k;}
 	}
 	public static class Matrix {public double a11,a12,a13,a21,a22,a23,a31,a32,a33; public Matrix(double a11i,double a12i,double a13i,double a21i,double a22i,double a23i,double a31i,double a32i,double a33i){this.a11=a11i;this.a12=a12i;this.a13=a13i;this.a21=a21i;this.a22=a22i;this.a23=a23i;this.a31=a31i;this.a32=a32i;this.a33=a33i;}
 		@Override public boolean equals(Object o) {

--- a/src/fi/jkauppa/javarenderengine/RenderLib.java
+++ b/src/fi/jkauppa/javarenderengine/RenderLib.java
@@ -47,7 +47,6 @@ public class RenderLib {
 		double pointdist = 1.0f;
 		int gridstep = 20;
 		RenderView renderview = new RenderView();
-		renderview.mode = 0;
 		renderview.mouselocationx = mouselocationx;
 		renderview.mouselocationy = mouselocationy;
 		renderview.pos = campos.copy();
@@ -150,7 +149,6 @@ public class RenderLib {
 
 	public static RenderView renderProjectedPolygonViewHardware(Position campos, Entity[] entitylist, int renderwidth, double hfov, int renderheight, double vfov, Matrix viewrot, boolean unlit, int bounces, Plane nclipplane, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = 1;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -172,31 +170,28 @@ public class RenderLib {
 		g2.fillRect(0, 0, renderwidth, renderheight);
 		g2.setComposite(AlphaComposite.SrcOver);
 		ArrayList<Triangle> mouseoverhittriangle = new ArrayList<Triangle>();
-		if (entitylist!=null) {
+		if ((entitylist!=null)&&(entitylist.length>0)) {
 			Sphere[] entityspherelist = new Sphere[entitylist.length]; 
 			for (int k=0;k<entitylist.length;k++) {
 				entityspherelist[k] = entitylist[k].sphereboundaryvolume;
-				entityspherelist[k].ind = k;
 			}
 			SphereDistanceComparator distcomp = new SphereDistanceComparator(renderview.pos);
-			Sphere[] sortedentityspherelist = Arrays.copyOf(entityspherelist, entityspherelist.length);
-			Arrays.sort(sortedentityspherelist, distcomp);
-			Rectangle[] sortedentityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, sortedentityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
-			for (int k=sortedentityspherelist.length-1;k>=0;k--) {
-				if (sortedentityspherelistint[k]!=null) {
-					Triangle[] copytrianglelist = entitylist[sortedentityspherelist[k].ind].trianglelist;
+			Integer[] sortedentityspherelistind = UtilLib.objectIndexSort(entityspherelist, distcomp);
+			Rectangle[] entityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, entityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
+			for (int k=sortedentityspherelistind.length-1;k>=0;k--) {
+				int et = sortedentityspherelistind[k];
+				if (entityspherelistint[et]!=null) {
+					Triangle[] copytrianglelist = entitylist[et].trianglelist;
 					if (copytrianglelist.length>0) {
 						Direction[] copytrianglenormallist = MathLib.triangleNormal(copytrianglelist);
 						Plane[] copytriangleplanelist = MathLib.trianglePlane(copytrianglelist);
 						RenderView[] copytrianglecameralist = MathLib.surfaceMirrorProjectedCamera(campos, copytriangleplanelist, viewrot);
 						Sphere[] copytrianglespherelist = MathLib.triangleCircumSphere(copytrianglelist);
-						for (int i=0;i<copytrianglespherelist.length;i++) {copytrianglespherelist[i].ind = i;}
+						Integer[] sortedtrianglespherelistind = UtilLib.objectIndexSort(copytrianglespherelist, distcomp);
 						Direction[] copyviewtrianglespheredir = MathLib.vectorFromPoints(campos, copytrianglespherelist);
-						Sphere[] sortedtrianglespherelist = Arrays.copyOf(copytrianglespherelist, copytrianglespherelist.length);
-						Arrays.sort(sortedtrianglespherelist, distcomp);
 						Coordinate[][] copytrianglelistcoords = MathLib.projectedTriangle(renderview.pos, copytrianglelist, renderwidth, renderview.hfov, renderheight, renderview.vfov, viewrot, nclipplane);
-						for (int i=sortedtrianglespherelist.length-1;i>=0;i--) {
-							int it = sortedtrianglespherelist[i].ind;
+						for (int i=sortedtrianglespherelistind.length-1;i>=0;i--) {
+							int it = sortedtrianglespherelistind[i];
 							Triangle[] copytriangle = {copytrianglelist[it]};
 							Direction copytrianglenormal = copytrianglenormallist[it];
 							Direction copytriangledir = copyviewtrianglespheredir[it];
@@ -232,7 +227,7 @@ public class RenderLib {
 										ArrayList<Entity> mirrorentitylistarray = new ArrayList<Entity>();
 										for (int m=0;m<entitylist.length;m++) {
 											if (entityspherepointlistdist[m][0]>=0.0f) {
-												mirrorentitylistarray.add(entitylist[m]);
+												mirrorentitylistarray.add(entitylist[m].copy());
 											}
 										}
 										Entity[] mirrorentitylist = mirrorentitylistarray.toArray(new Entity[mirrorentitylistarray.size()]);
@@ -264,7 +259,6 @@ public class RenderLib {
 	
 	public static RenderView renderProjectedPlaneViewSoftware(Position campos, Entity[] entitylist, int renderwidth, double hfov, int renderheight, double vfov, Matrix viewrot, boolean unlit, Plane nclipplane, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = 2;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -289,7 +283,7 @@ public class RenderLib {
 		g2.fillRect(0, 0, renderwidth, renderheight);
 		g2.setComposite(AlphaComposite.SrcOver);
 		ArrayList<Triangle> mouseoverhittriangle = new ArrayList<Triangle>();
-		if (entitylist!=null) {
+		if ((entitylist!=null)&&(entitylist.length>0)) {
 			Direction[] camdir = {renderview.dirs[0]};
 			Position[] camposa = {renderview.pos};
 			Position[] rendercutpos = MathLib.translate(camposa, renderview.dirs[0], 1.1d);
@@ -304,24 +298,21 @@ public class RenderLib {
 			Sphere[] entityspherelist = new Sphere[entitylist.length]; 
 			for (int k=0;k<entitylist.length;k++) {
 				entityspherelist[k] = entitylist[k].sphereboundaryvolume;
-				entityspherelist[k].ind = k;
 			}
 			SphereDistanceComparator distcomp = new SphereDistanceComparator(renderview.pos);
-			Sphere[] sortedentityspherelist = Arrays.copyOf(entityspherelist, entityspherelist.length);
-			Arrays.sort(sortedentityspherelist, distcomp);
-			Rectangle[] sortedentityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, sortedentityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
-			for (int k=sortedentityspherelist.length-1;k>=0;k--) {
-				if (sortedentityspherelistint[k]!=null) {
-					Triangle[] copytrianglelist = entitylist[sortedentityspherelist[k].ind].trianglelist;
+			Integer[] sortedentityspherelistind = UtilLib.objectIndexSort(entityspherelist, distcomp);
+			Rectangle[] sortedentityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, entityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
+			for (int k=sortedentityspherelistind.length-1;k>=0;k--) {
+				int et = sortedentityspherelistind[k];
+				if (sortedentityspherelistint[et]!=null) {
+					Triangle[] copytrianglelist = entitylist[et].trianglelist;
 					if (copytrianglelist.length>0) {
 						Direction[] copytrianglenormallist = MathLib.triangleNormal(copytrianglelist);
 						Sphere[] copytrianglespherelist = MathLib.triangleCircumSphere(copytrianglelist);
-						for (int i=0;i<copytrianglespherelist.length;i++) {copytrianglespherelist[i].ind = i;}
-						Sphere[] sortedtrianglespherelist = Arrays.copyOf(copytrianglespherelist, copytrianglespherelist.length);
-						Arrays.sort(sortedtrianglespherelist, distcomp);
+						Integer[] sortedtrianglespherelistind = UtilLib.objectIndexSort(copytrianglespherelist, distcomp);
 						Rectangle[] copytrianglelistint = MathLib.projectedTriangleIntersection(renderview.pos, copytrianglelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
-						for (int i=sortedtrianglespherelist.length-1;i>=0;i--) {
-							int it = sortedtrianglespherelist[i].ind;
+						for (int i=sortedtrianglespherelistind.length-1;i>=0;i--) {
+							int it = sortedtrianglespherelistind[i];
 							if (copytrianglelistint[it]!=null) {
 								Triangle[] copytriangle = {copytrianglelist[it]};
 								Direction copytrianglenormal = copytrianglenormallist[it];
@@ -436,7 +427,6 @@ public class RenderLib {
 	
 	public static RenderView renderSpheremapPlaneViewSoftware(Position campos, Entity[] entitylist, int renderwidth, int renderheight, Matrix viewrot, boolean unlit, Plane nclipplane, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = 3;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -462,7 +452,7 @@ public class RenderLib {
 		g2.fillRect(0, 0, renderwidth, renderheight);
 		g2.setComposite(AlphaComposite.SrcOver);
 		ArrayList<Triangle> mouseoverhittriangle = new ArrayList<Triangle>();
-		if (entitylist!=null) {
+		if ((entitylist!=null)&&(entitylist.length>0)) {
 			double[] verticalangles = MathLib.spheremapAngles(renderheight, 180.0f);
 			double halfvfovmult = (1.0f/(renderview.vfov/2.0f));
 			double origindeltay = ((double)(renderheight-1))/2.0f;
@@ -481,24 +471,21 @@ public class RenderLib {
 			Sphere[] entityspherelist = new Sphere[entitylist.length]; 
 			for (int k=0;k<entitylist.length;k++) {
 				entityspherelist[k] = entitylist[k].sphereboundaryvolume;
-				entityspherelist[k].ind = k;
 			}
 			SphereDistanceComparator distcomp = new SphereDistanceComparator(renderview.pos);
-			Sphere[] sortedentityspherelist = Arrays.copyOf(entityspherelist, entityspherelist.length);
-			Arrays.sort(sortedentityspherelist, distcomp);
-			Rectangle[] sortedentityspherelistint = MathLib.spheremapSphereIntersection(renderview.pos, sortedentityspherelist, renderwidth, renderheight, viewrot, nclipplane);
-			for (int k=sortedentityspherelist.length-1;k>=0;k--) {
-				if (sortedentityspherelistint[k]!=null) {
-					Triangle[] copytrianglelist = entitylist[sortedentityspherelist[k].ind].trianglelist;
+			Integer[] sortedentityspherelistind = UtilLib.objectIndexSort(entityspherelist, distcomp);
+			Rectangle[] sortedentityspherelistint = MathLib.spheremapSphereIntersection(renderview.pos, entityspherelist, renderwidth, renderheight, viewrot, nclipplane);
+			for (int k=sortedentityspherelistind.length-1;k>=0;k--) {
+				int et = sortedentityspherelistind[k];
+				if (sortedentityspherelistint[et]!=null) {
+					Triangle[] copytrianglelist = entitylist[et].trianglelist;
 					if (copytrianglelist.length>0) {
 						Direction[] copytrianglenormallist = MathLib.triangleNormal(copytrianglelist);
 						Sphere[] copytrianglespherelist = MathLib.triangleCircumSphere(copytrianglelist);
-						for (int i=0;i<copytrianglespherelist.length;i++) {copytrianglespherelist[i].ind = i;}
-						Sphere[] sortedtrianglespherelist = Arrays.copyOf(copytrianglespherelist, copytrianglespherelist.length);
-						Arrays.sort(sortedtrianglespherelist, distcomp);
+						Integer[] sortedtrianglespherelistind = UtilLib.objectIndexSort(copytrianglespherelist, distcomp);
 						Rectangle[] copytrianglelistint = MathLib.spheremapTriangleIntersection(renderview.pos, copytrianglelist, renderwidth, renderheight, viewrot, nclipplane);
-						for (int i=sortedtrianglespherelist.length-1;i>=0;i--) {
-							int it = sortedtrianglespherelist[i].ind;
+						for (int i=sortedtrianglespherelistind.length-1;i>=0;i--) {
+							int it = sortedtrianglespherelistind[i];
 							if (copytrianglelistint[it]!=null) {
 								Triangle[] copytriangle = {copytrianglelist[it]};
 								Direction copytrianglenormal = copytrianglenormallist[it];
@@ -641,7 +628,6 @@ public class RenderLib {
 
 	public static RenderView renderProjectedRayViewSoftware(Position campos, Entity[] entitylist, int renderwidth, double hfov, int renderheight, double vfov, Matrix viewrot, boolean unlit, Plane nclipplane, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = 4;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -666,31 +652,27 @@ public class RenderLib {
 		g2.fillRect(0, 0, renderwidth, renderheight);
 		g2.setComposite(AlphaComposite.SrcOver);
 		ArrayList<Triangle> mouseoverhittriangle = new ArrayList<Triangle>();
-		if (entitylist!=null) {
+		if ((entitylist!=null)&&(entitylist.length>0)) {
 			Plane[] camdirrightupplanes = MathLib.planeFromNormalAtPoint(renderview.pos, renderview.dirs);
 			Plane[] camfwdplane = {camdirrightupplanes[0]};
 			Sphere[] entityspherelist = new Sphere[entitylist.length]; 
 			for (int k=0;k<entitylist.length;k++) {
 				entityspherelist[k] = entitylist[k].sphereboundaryvolume;
-				entityspherelist[k].ind = k;
 			}
 			SphereDistanceComparator distcomp = new SphereDistanceComparator(renderview.pos);
-			Sphere[] sortedentityspherelist = Arrays.copyOf(entityspherelist, entityspherelist.length);
-			Arrays.sort(sortedentityspherelist, distcomp);
-			Rectangle[] sortedentityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, sortedentityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
-			for (int k=sortedentityspherelist.length-1;k>=0;k--) {
-				if (sortedentityspherelistint[k]!=null) {
-					Entity sortedentity = entitylist[sortedentityspherelist[k].ind];
-					Triangle[] copytrianglelist = sortedentity.trianglelist;
+			Integer[] sortedentityspherelistind = UtilLib.objectIndexSort(entityspherelist, distcomp);
+			Rectangle[] sortedentityspherelistint = MathLib.projectedSphereIntersection(renderview.pos, entityspherelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
+			for (int k=sortedentityspherelistind.length-1;k>=0;k--) {
+				int et = sortedentityspherelistind[k];
+				if (sortedentityspherelistint[et]!=null) {
+					Triangle[] copytrianglelist = entitylist[et].trianglelist;
 					if (copytrianglelist.length>0) {
 						Direction[] copytrianglenormallist = MathLib.triangleNormal(copytrianglelist);
 						Sphere[] copytrianglespherelist = MathLib.triangleCircumSphere(copytrianglelist);
-						for (int i=0;i<copytrianglespherelist.length;i++) {copytrianglespherelist[i].ind = i;}
-						Sphere[] sortedtrianglespherelist = Arrays.copyOf(copytrianglespherelist, copytrianglespherelist.length);
-						Arrays.sort(sortedtrianglespherelist, distcomp);
+						Integer[] sortedtrianglespherelistind = UtilLib.objectIndexSort(copytrianglespherelist, distcomp);
 						Rectangle[] copytrianglelistint = MathLib.projectedTriangleIntersection(renderview.pos, copytrianglelist, renderwidth, renderheight, renderview.hfov, renderview.vfov, viewrot, nclipplane);
-						for (int n=sortedtrianglespherelist.length-1;n>=0;n--) {
-							int it = sortedtrianglespherelist[n].ind;
+						for (int n=sortedtrianglespherelistind.length-1;n>=0;n--) {
+							int it = sortedtrianglespherelistind[n];
 							if (copytrianglelistint[it]!=null) {
 								Triangle[] copytriangle = {copytrianglelist[it]};
 								Direction copytrianglenormal = copytrianglenormallist[it];
@@ -742,7 +724,6 @@ public class RenderLib {
 
 	public static RenderView renderSpheremapRayViewSoftware(Position campos, Entity[] entitylist, int renderwidth, int renderheight, Matrix viewrot, boolean unlit, Plane nclipplane, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = 5;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -768,30 +749,26 @@ public class RenderLib {
 		g2.fillRect(0, 0, renderwidth, renderheight);
 		g2.setComposite(AlphaComposite.SrcOver);
 		ArrayList<Triangle> mouseoverhittriangle = new ArrayList<Triangle>();
-		if (entitylist!=null) {
+		if ((entitylist!=null)&&(entitylist.length>0)) {
 			Plane[] camfwdplanes = MathLib.planeFromNormalAtPoint(renderview.pos, renderview.fwddirs);
 			Sphere[] entityspherelist = new Sphere[entitylist.length]; 
 			for (int k=0;k<entitylist.length;k++) {
 				entityspherelist[k] = entitylist[k].sphereboundaryvolume;
-				entityspherelist[k].ind = k;
 			}
 			SphereDistanceComparator distcomp = new SphereDistanceComparator(renderview.pos);
-			Sphere[] sortedentityspherelist = Arrays.copyOf(entityspherelist, entityspherelist.length);
-			Arrays.sort(sortedentityspherelist, distcomp);
-			Rectangle[] sortedentityspherelistint = MathLib.spheremapSphereIntersection(renderview.pos, sortedentityspherelist, renderwidth, renderheight, viewrot, nclipplane);
-			for (int k=sortedentityspherelist.length-1;k>=0;k--) {
-				if (sortedentityspherelistint[k]!=null) {
-					Entity sortedentity = entitylist[sortedentityspherelist[k].ind];
-					Triangle[] copytrianglelist = sortedentity.trianglelist;
+			Integer[] sortedentityspherelistind = UtilLib.objectIndexSort(entityspherelist, distcomp);
+			Rectangle[] sortedentityspherelistint = MathLib.spheremapSphereIntersection(renderview.pos, entityspherelist, renderwidth, renderheight, viewrot, nclipplane);
+			for (int k=sortedentityspherelistind.length-1;k>=0;k--) {
+				int et = sortedentityspherelistind[k];
+				if (sortedentityspherelistint[et]!=null) {
+					Triangle[] copytrianglelist = entitylist[et].trianglelist;
 					if (copytrianglelist.length>0) {
 						Direction[] copytrianglenormallist = MathLib.triangleNormal(copytrianglelist);
 						Sphere[] copytrianglespherelist = MathLib.triangleCircumSphere(copytrianglelist);
-						for (int i=0;i<copytrianglespherelist.length;i++) {copytrianglespherelist[i].ind = i;}
-						Sphere[] sortedtrianglespherelist = Arrays.copyOf(copytrianglespherelist, copytrianglespherelist.length);
-						Arrays.sort(sortedtrianglespherelist, distcomp);
+						Integer[] sortedtrianglespherelistind = UtilLib.objectIndexSort(copytrianglespherelist, distcomp);
 						Rectangle[] copytrianglelistint = MathLib.spheremapTriangleIntersection(renderview.pos, copytrianglelist, renderwidth, renderheight, viewrot, nclipplane);
-						for (int n=sortedtrianglespherelist.length-1;n>=0;n--) {
-							int it = sortedtrianglespherelist[n].ind;
+						for (int n=sortedtrianglespherelistind.length-1;n>=0;n--) {
+							int it = sortedtrianglespherelistind[n];
 							if (copytrianglelistint[it]!=null) {
 								Triangle[] copytriangle = {copytrianglelist[it]};
 								Direction copytrianglenormal = copytrianglenormallist[it];
@@ -884,7 +861,7 @@ public class RenderLib {
 		ArrayList<Entity> mirrorentitylistarray = new ArrayList<Entity>();
 		for (int i=0;i<entitylist.length;i++) {
 			if (entityspherepointlistdist[i][0]>=0.0f) {
-				mirrorentitylistarray.add(entitylist[i]);
+				mirrorentitylistarray.add(entitylist[i].copy());
 			}
 		}
 		Entity[] mirrorentitylist = mirrorentitylistarray.toArray(new Entity[mirrorentitylistarray.size()]);
@@ -911,7 +888,6 @@ public class RenderLib {
 	}
 	public static RenderView renderCubemapView(Position campos, Entity[] entitylist, int renderwidth, int renderheight, int rendersize, Matrix viewrot, boolean unlit, int mode, int bounces, int mouselocationx, int mouselocationy) {
 		RenderView renderview = new RenderView();
-		renderview.mode = (mode>0)?mode:1;
 		renderview.pos = campos.copy();
 		renderview.rot = viewrot.copy();
 		renderview.renderwidth = renderwidth;
@@ -922,6 +898,7 @@ public class RenderLib {
 		renderview.unlit = unlit;
 		renderview.mouselocationx = mouselocationx;
 		renderview.mouselocationy = mouselocationy;
+		int rendermode = (mode>0)?mode:1;
 		int renderposx1start = 0;
 		int renderposx1end = rendersize-1;
 		int renderposx2start = rendersize;
@@ -945,12 +922,12 @@ public class RenderLib {
 		backwardmatrix = MathLib.matrixMultiply(renderview.rot, backwardmatrix);
 		leftmatrix = MathLib.matrixMultiply(renderview.rot, leftmatrix);
 		renderview.cubemap = new Cubemap();
-		renderview.cubemap.topview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, topmatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy);
-		renderview.cubemap.bottomview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, bottommatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy); 
-		renderview.cubemap.forwardview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, forwardmatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy);
-		renderview.cubemap.rightview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, rightmatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy);
-		renderview.cubemap.backwardview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, backwardmatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy);
-		renderview.cubemap.leftview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, leftmatrix, renderview.unlit, renderview.mode, bounces, mouselocationx, mouselocationy);
+		renderview.cubemap.topview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, topmatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy);
+		renderview.cubemap.bottomview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, bottommatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy); 
+		renderview.cubemap.forwardview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, forwardmatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy);
+		renderview.cubemap.rightview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, rightmatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy);
+		renderview.cubemap.backwardview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, backwardmatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy);
+		renderview.cubemap.leftview = renderProjectedView(renderview.pos, entitylist, renderview.rendersize, renderview.vfov, renderview.rendersize, renderview.vfov, leftmatrix, renderview.unlit, rendermode, bounces, mouselocationx, mouselocationy);
 		renderview.renderimage = gc.createCompatibleVolatileImage(renderwidth, renderheight, Transparency.TRANSLUCENT);
 		Graphics2D rigfx = renderview.renderimage.createGraphics();
 		rigfx.setComposite(AlphaComposite.Src);

--- a/src/fi/jkauppa/javarenderengine/UtilLib.java
+++ b/src/fi/jkauppa/javarenderengine/UtilLib.java
@@ -17,6 +17,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Arrays;
+import java.util.Comparator;
 
 import javax.imageio.ImageIO;
 import javax.swing.filechooser.FileFilter;
@@ -142,11 +143,36 @@ public class UtilLib {
 		return k;
 	}
 
-	public static int snapToGrid(int coordinate, int gridstep) {
-		return gridstep*(int)Math.round(((double)coordinate)/((double)gridstep));
+	public static class ObjectSort<T> implements Comparator<Integer> {
+		private Comparable<T>[] data;
+		private Comparator<T> comp;
+		public ObjectSort(Comparable<T>[] datai, Comparator<T> compi) {this.data=datai;this.comp=compi;}
+		@SuppressWarnings("unchecked")
+		@Override public int compare(Integer o1, Integer o2) {
+			int compval = -1;
+			if (this.comp!=null) {
+				compval = this.comp.compare((T)data[o1],(T)data[o2]);
+			} else {
+				compval = data[o1].compareTo((T)data[o2]);
+			}
+	        return compval;
+		}
+	}
+	public static <T> Integer[] objectIndexSort(Comparable<T>[] data, Comparator<T> comp) {
+		Integer[] k = null;
+		if ((data!=null)&&(data.length>0)) {
+			Integer[] indices = new Integer[data.length];
+			for (int i = 0; i < indices.length; i++) {
+			    indices[i] = i;
+			}
+			ObjectSort<T> comparator = new ObjectSort<T>(data, comp);
+			Arrays.sort(indices, comparator);
+			k = indices;
+		}
+		return k;
 	}
 
-    static class ImageTransferable implements Transferable {
+	static class ImageTransferable implements Transferable {
         private Image image;
         public ImageTransferable (Image imagei) {this.image=imagei;}
         public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {if (isDataFlavorSupported(flavor)) {return image;}else{throw new UnsupportedFlavorException(flavor);}}


### PR DESCRIPTION
Updated renderView functions to use local index sorting arrays instead of entity and triangle indices to prevent overwriting from recursion modifications RenderLib.
Updated renderView hardware functions to experimentally draw one bounce mirror camera surfaces on triangle textures in ModelApp and two bounce mirror camera surfaces on triangle textures during light map calculation in CADApp.
Added implementation of generic object array index sorting function objectIndexSort in UtilLib.