### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/CADApp.java
+++ b/src/fi/jkauppa/javarenderengine/CADApp.java
@@ -1214,10 +1214,10 @@ public class CADApp extends AppHandlerPanel {
 					CADApp.this.mouseoverline = CADApp.this.renderview.mouseoverline;
 					CADApp.this.mouseoververtex = CADApp.this.renderview.mouseoververtex;
 				} else if (CADApp.this.polygonfillmode==2) { 
-					CADApp.this.renderview = RenderLib.renderProjectedView(CADApp.this.campos, CADApp.this.entitylist, CADApp.this.getWidth(), CADApp.this.hfov, CADApp.this.getHeight(), CADApp.this.vfov, CADApp.this.cameramat, CADApp.this.unlitrender, 1, bounces, CADApp.this.mouselocationx, CADApp.this.mouselocationy);
+					CADApp.this.renderview = RenderLib.renderProjectedView(CADApp.this.campos, CADApp.this.entitylist, CADApp.this.getWidth(), CADApp.this.hfov, CADApp.this.getHeight(), CADApp.this.vfov, CADApp.this.cameramat, CADApp.this.unlitrender, 1, bounces, null, null, null, CADApp.this.mouselocationx, CADApp.this.mouselocationy);
 					CADApp.this.mouseovertriangle = CADApp.this.renderview.mouseovertriangle;
 				} else if (CADApp.this.polygonfillmode==3) {
-					CADApp.this.renderview = RenderLib.renderProjectedView(CADApp.this.campos, CADApp.this.entitylist, CADApp.this.getWidth(), CADApp.this.hfov, CADApp.this.getHeight(), CADApp.this.vfov, CADApp.this.cameramat, CADApp.this.unlitrender, 2, bounces, CADApp.this.mouselocationx, CADApp.this.mouselocationy);
+					CADApp.this.renderview = RenderLib.renderProjectedView(CADApp.this.campos, CADApp.this.entitylist, CADApp.this.getWidth(), CADApp.this.hfov, CADApp.this.getHeight(), CADApp.this.vfov, CADApp.this.cameramat, CADApp.this.unlitrender, 2, bounces, null, null, null, CADApp.this.mouselocationx, CADApp.this.mouselocationy);
 					CADApp.this.mouseovertriangle = CADApp.this.renderview.mouseovertriangle;
 				}
 				RenderViewUpdater.renderupdaterrunning = false;
@@ -1230,7 +1230,7 @@ public class CADApp extends AppHandlerPanel {
 		public void run() {
 			if (!EntityLightMapUpdater.entitylightmapupdaterrunning) {
 				EntityLightMapUpdater.entitylightmapupdaterrunning = true;
-				int bounces = 2;
+				int bounces = 1;
 				if (CADApp.this.polygonfillmode==1) {
 					RenderLib.renderSurfaceFaceLightmapCubemapView(CADApp.this.entitylist, 32, bounces, 3);
 				} else if (CADApp.this.polygonfillmode==2) {

--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -62,7 +62,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.3.34");
+		this.setTitle("Java Render Engine v2.3.35");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {

--- a/src/fi/jkauppa/javarenderengine/MathLib.java
+++ b/src/fi/jkauppa/javarenderengine/MathLib.java
@@ -1665,7 +1665,7 @@ public class MathLib {
 			Position[] camposa = {vpos};
 			Position[] rendercutpos = translate(camposa, dirs[0], 1.1d);
 			Plane[] rendercutplane = planeFromNormalAtPoint(rendercutpos, camdir);
-			Plane[] nearclipplane = {nclipplane};
+			Plane[] neartriclipplane = {nclipplane};
 			Position[][] vtripos = new Position[5][vtri.length];
 			Coordinate[][] vtripospixels = new Coordinate[3][vtri.length];
 			for (int i=0;i<vtri.length;i++) {
@@ -1677,7 +1677,7 @@ public class MathLib {
 				vtripospixels[j] = projectedPoint(vpos, vtripos[j], hres, hfov, vres, vfov, vmat, nclipplane);
 				double[][] vtripospixeldist = null;
 				if (nclipplane!=null) {
-					vtripospixeldist = planePointDistance(vtripos[j], nearclipplane);
+					vtripospixeldist = planePointDistance(vtripos[j], neartriclipplane);
 				}
 				for (int i=0;i<vtripos[j].length;i++) {
 					if ((nclipplane==null)||(vtripospixeldist[i][0]>=0.1f)) {
@@ -1958,12 +1958,12 @@ public class MathLib {
 		Matrix rotxp90zn90 = matrixMultiply(rotzn90, rotxp90);
 		Matrix rotxp90zp90 = matrixMultiply(rotzp90, rotxp90);
 		Matrix rotxp90zp180 = matrixMultiply(rotzp180, rotxp90);
-		k[0] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zn90, null);
-		k[1] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90, null);
-		k[2] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zp90, null);
-		k[3] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zp180, null);
-		k[4] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp180, null);
-		k[5] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp0, null);
+		k[0] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zn90, nclipplane);
+		k[1] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90, nclipplane);
+		k[2] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zp90, nclipplane);
+		k[3] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp90zp180, nclipplane);
+		k[4] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp180, nclipplane);
+		k[5] = projectedSphereIntersection(vpos, vsphere, vres, vres, 90, 90, rotxp0, nclipplane);
 		return k;
 	}
 

--- a/src/fi/jkauppa/javarenderengine/ModelApp.java
+++ b/src/fi/jkauppa/javarenderengine/ModelApp.java
@@ -298,23 +298,23 @@ public class ModelApp extends AppHandlerPanel {
 				RenderViewUpdater.renderupdaterrunning = true;
 				int bounces = 1;
 				if (ModelApp.this.polygonfillmode==1) {
-					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==2) {
 					ModelApp.this.renderview = RenderLib.renderProjectedMirrorView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==3) {
-					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==4) {
-					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==5) {
-					ModelApp.this.renderview = RenderLib.renderSpheremapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderSpheremapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), ModelApp.this.cameramat, ModelApp.this.unlitrender, 1, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==6) {
-					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==7) {
-					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 3, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderProjectedView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.hfov, ModelApp.this.getHeight(), ModelApp.this.vfov, ModelApp.this.cameramat, ModelApp.this.unlitrender, 3, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==8) {
-					ModelApp.this.renderview = RenderLib.renderSpheremapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderSpheremapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), ModelApp.this.cameramat, ModelApp.this.unlitrender, 2, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				} else if (ModelApp.this.polygonfillmode==9) {
-					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 3, bounces, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
+					ModelApp.this.renderview = RenderLib.renderCubemapView(ModelApp.this.campos, ModelApp.this.entitylist, ModelApp.this.getWidth(), ModelApp.this.getHeight(), (int)Math.floor(((double)ModelApp.this.getHeight())/2.0f), ModelApp.this.cameramat, ModelApp.this.unlitrender, 3, bounces, null, null, null, ModelApp.this.mouselocationx, ModelApp.this.mouselocationy);
 				}
 				RenderViewUpdater.renderupdaterrunning = false;
 			}

--- a/src/fi/jkauppa/javarenderengine/ModelLib.java
+++ b/src/fi/jkauppa/javarenderengine/ModelLib.java
@@ -85,7 +85,7 @@ public class ModelLib {
 			return k;}
 		@Override public boolean equals(Object o) {
 			boolean k=false;
-			if (o.getClass().equals(this.getClass())){
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))){
 				Material co=(Material)o;
 				if(this.compareTo(co)==0){
 					k=true;
@@ -196,7 +196,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Position os = (Position)o;
 				if ((this.x==os.x)&&(this.y==os.y)&&(this.z==os.z)) {
 					k = true;
@@ -229,7 +229,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Direction os = (Direction)o;
 				if ((this.dx==os.dx)&&(this.dy==os.dy)&&(this.dz==os.dz)) {
 					k = true;
@@ -258,7 +258,7 @@ public class ModelLib {
 	}
 	@Override public boolean equals(Object o) {
 		boolean k = false;
-		if (o.getClass().equals(this.getClass())) {
+		if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 			Coordinate os = (Coordinate)o;
 			if ((this.u==os.u)&&(this.v==os.v)) {
 				k = true;
@@ -274,7 +274,7 @@ public class ModelLib {
 	public static class Rotation {public double x,y,z; public Rotation(double xi,double yi,double zi){this.x=xi;this.y=yi;this.z=zi;}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Rotation os = (Rotation)o;
 				if ((this.x==os.x)&&(this.y==os.y)&&(this.z==os.z)) {
 					k = true;
@@ -308,7 +308,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Sphere os = (Sphere)o;
 				if ((this.x==os.x)&&(this.y==os.y)&&(this.z==os.z)&&(this.r==os.r)) {
 					k = true;
@@ -374,7 +374,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Line os = ((Line)o).sort();
 				Line ts=this.sort();
 				if ((ts.pos1.x==os.pos1.x)&&(ts.pos1.y==os.pos1.y)&&(ts.pos1.z==os.pos1.z)&&(ts.pos2.x==os.pos2.x)&&(ts.pos2.y==os.pos2.y)&&(ts.pos2.z==os.pos2.z)) {
@@ -437,7 +437,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Tetrahedron co = (Tetrahedron)o;
 				Position[] tp = {this.pos1,this.pos2,this.pos3,this.pos4};
 				Position[] op = {co.pos1,co.pos2,co.pos3,this.pos4};
@@ -454,7 +454,8 @@ public class ModelLib {
 			return k;
 		}
 	}
-	public static class Triangle implements Comparable<Triangle> {public Position pos1,pos2,pos3; public Direction norm; public Material mat = null; public Material[] lmatl = null; public Triangle(Position pos1i,Position pos2i,Position pos3i){this.pos1=pos1i;this.pos2=pos2i;this.pos3=pos3i;}
+	public static class Triangle implements Comparable<Triangle> {public Position pos1,pos2,pos3; public Direction norm; public Material mat = null; public Material[] lmatl = null;
+		public Triangle(Position pos1i,Position pos2i,Position pos3i) {this.pos1=pos1i;this.pos2=pos2i;this.pos3=pos3i;}
 		@Override public int compareTo(Triangle o) {
 			int k = -1;
 			Position[] tposarray = {this.pos1,this.pos2,this.pos3};
@@ -494,7 +495,7 @@ public class ModelLib {
 		}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Triangle co = (Triangle)o;
 				Position[] tposarray = {this.pos1,this.pos2,this.pos3};
 				Position[] oposarray = {co.pos1,co.pos2,co.pos3};
@@ -523,7 +524,7 @@ public class ModelLib {
 	public static class Matrix {public double a11,a12,a13,a21,a22,a23,a31,a32,a33; public Matrix(double a11i,double a12i,double a13i,double a21i,double a22i,double a23i,double a31i,double a32i,double a33i){this.a11=a11i;this.a12=a12i;this.a13=a13i;this.a21=a21i;this.a22=a22i;this.a23=a23i;this.a31=a31i;this.a32=a32i;this.a33=a33i;}
 		@Override public boolean equals(Object o) {
 			boolean k = false;
-			if (o.getClass().equals(this.getClass())) {
+			if ((o!=null)&&(o.getClass().equals(this.getClass()))) {
 				Matrix co = (Matrix)o;
 				if ((this.a11==co.a11)&&(this.a12==co.a12)&&(this.a13==co.a13)&&(this.a21==co.a21)&&(this.a22==co.a22)&&(this.a23==co.a23)&&(this.a31==co.a31)&&(this.a32==co.a32)&&(this.a33==co.a33)) {
 					k = true;


### PR DESCRIPTION
Updated renderProjectedPolygonViewHardware function to limit mirrors to metallic>0 materials and drawrange rectangle based on polygon draw area.
Updated renderProjectedPolygonViewHardware and renderSurfaceFaceLightmapCubemapView functions not to draw triangle that is mirror/probe surface.
Note: mirrors oriented vertically down/up do not to calculate camera correctly. OBJ Model file saving of lightmaps does not seem to be exactly correct.