### PR TITLE
Updated RenderLib

### DIFF
--- a/src/fi/jkauppa/javarenderengine/CADApp.java
+++ b/src/fi/jkauppa/javarenderengine/CADApp.java
@@ -53,6 +53,7 @@ public class CADApp extends AppHandlerPanel {
 	private boolean texturemode = false;
 	private boolean erasemode = false;
 	private Material drawmat = new Material(Color.getHSBColor(0.0f, 0.0f, 1.0f),1.0f,null);
+	private int renderoutputwidth = 3840, renderoutputheight = 2160;
 	private int polygonfillmode = 1;
 	private boolean unlitrender = false;
 	private Position[] selecteddragvertex = null;
@@ -795,6 +796,45 @@ public class CADApp extends AppHandlerPanel {
 					}
 				}
 		    }
+		} else if (e.getKeyCode()==KeyEvent.VK_F4) {
+		    int onmask = KeyEvent.SHIFT_DOWN_MASK;
+		    int offmask = KeyEvent.ALT_DOWN_MASK|KeyEvent.CTRL_DOWN_MASK;
+		    boolean f4shiftdown = (e.getModifiersEx() & (onmask | offmask)) == onmask;
+			this.imagechooser.setDialogTitle("Render File");
+			this.imagechooser.setApproveButtonText("Render");
+			if (this.imagechooser.showOpenDialog(null)==JFileChooser.APPROVE_OPTION) {
+				File savefile = this.imagechooser.getSelectedFile();
+				FileFilter savefileformat = this.imagechooser.getFileFilter();
+				RenderView renderimageview = RenderLib.renderProjectedView(this.campos, this.entitylist, this.renderoutputwidth, this.hfov, this.renderoutputheight, this.vfov, this.cameramat, this.unlitrender, 3, 2, null, null, null, this.mouselocationx, this.mouselocationy);
+				VolatileImage renderimage = renderimageview.renderimage;
+				if (!f4shiftdown) {
+					VolatileImage blackbgimage = gc.createCompatibleVolatileImage(renderimage.getWidth(), renderimage.getHeight(), Transparency.TRANSLUCENT);
+					Graphics2D bbggfx = blackbgimage.createGraphics();
+					bbggfx.setComposite(AlphaComposite.Src);
+					bbggfx.setColor(Color.BLACK);
+					bbggfx.fillRect(0, 0, renderimage.getWidth(), renderimage.getHeight());
+					bbggfx.setComposite(AlphaComposite.SrcOver);
+					bbggfx.drawImage(renderimage, 0, 0, null);
+					bbggfx.dispose();
+					renderimage = blackbgimage;
+				}
+				if (savefileformat.equals(this.jpgfilefilter)) {
+					if ((!savefile.getName().toLowerCase().endsWith(".jpg"))&&(!savefile.getName().toLowerCase().endsWith(".jpeg"))) {savefile = new File(savefile.getPath().concat(".jpg"));}
+					UtilLib.saveImage(savefile.getPath(), renderimage, "JPG");
+				} else if (savefileformat.equals(this.giffilefilter)) {
+					if (!savefile.getName().toLowerCase().endsWith(".gif")) {savefile = new File(savefile.getPath().concat(".gif"));}
+					UtilLib.saveImage(savefile.getPath(), renderimage, "GIF");
+				} else if (savefileformat.equals(this.bmpfilefilter)) {
+					if (!savefile.getName().toLowerCase().endsWith(".bmp")) {savefile = new File(savefile.getPath().concat(".bmp"));}
+					UtilLib.saveImage(savefile.getPath(), renderimage, "BMP");
+				} else if (savefileformat.equals(this.wbmpfilefilter)) {
+					if (!savefile.getName().toLowerCase().endsWith(".wbmp")) {savefile = new File(savefile.getPath().concat(".wbmp"));}
+					UtilLib.saveImage(savefile.getPath(), renderimage, "WBMP");
+				} else {
+					if (!savefile.getName().toLowerCase().endsWith(".png")) {savefile = new File(savefile.getPath().concat(".png"));}
+					UtilLib.saveImage(savefile.getPath(), renderimage, "PNG");
+				}
+			}
 		}
 	}
 	

--- a/src/fi/jkauppa/javarenderengine/DrawApp.java
+++ b/src/fi/jkauppa/javarenderengine/DrawApp.java
@@ -238,7 +238,7 @@ public class DrawApp extends AppHandlerPanel {
 				File savefile = this.filechooser.getSelectedFile();
 				FileFilter savefileformat = this.filechooser.getFileFilter();
 				if (savefileformat.equals(this.jpgfilefilter)) {
-					if (!savefile.getName().toLowerCase().endsWith(".obj")) {savefile = new File(savefile.getPath().concat(".obj"));}
+					if ((!savefile.getName().toLowerCase().endsWith(".jpg"))&&(!savefile.getName().toLowerCase().endsWith(".jpeg"))) {savefile = new File(savefile.getPath().concat(".jpg"));}
 					try {ImageIO.write(this.renderbuffer.getSnapshot(), "JPG", savefile);} catch (Exception ex) {ex.printStackTrace();}
 				} else if (savefileformat.equals(this.giffilefilter)) {
 					if (!savefile.getName().toLowerCase().endsWith(".gif")) {savefile = new File(savefile.getPath().concat(".gif"));}

--- a/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
+++ b/src/fi/jkauppa/javarenderengine/JavaRenderEngine.java
@@ -64,7 +64,7 @@ public class JavaRenderEngine extends JFrame implements ActionListener,KeyListen
 	
 	public JavaRenderEngine() {
 		if (this.logoimage!=null) {this.setIconImage(this.logoimage);}
-		this.setTitle("Java Render Engine v2.5.3");
+		this.setTitle("Java Render Engine v2.5.4");
 		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setJMenuBar(null);
 		if (!windowedmode) {

--- a/src/fi/jkauppa/javarenderengine/RenderLib.java
+++ b/src/fi/jkauppa/javarenderengine/RenderLib.java
@@ -217,7 +217,7 @@ public class RenderLib {
 									}
 									Color trianglecolor = trianglePixelShader(renderview.pos, copytriangle[0], copytrianglenormal[0], null, copytriangledir, unlit);
 									if (trianglecolor!=null) {
-										if (copytriangle[0].norm.isZero()) {
+										if ((bounces<=0)||(copytriangle[0].norm.isZero())) {
 											g2.setComposite(AlphaComposite.SrcOver);
 										} else {
 											g2.setComposite(AlphaComposite.Src);
@@ -459,7 +459,7 @@ public class RenderLib {
 														}
 														Color trianglecolor = trianglePixelShader(renderview.pos, copytriangle[0], copytrianglenormal[0], lineuv, camray[0], unlit);
 														if (trianglecolor!=null) {
-															if (copytriangle[0].norm.isZero()) {
+															if ((bounces<=0)||(copytriangle[0].norm.isZero())) {
 																g2.setComposite(AlphaComposite.SrcOver);
 															} else {
 																g2.setComposite(AlphaComposite.Src);
@@ -652,7 +652,7 @@ public class RenderLib {
 												}
 												Color trianglecolor = trianglePixelShader(renderview.pos, copytriangle[0], copytrianglenormal[0], pointuv, camray[0], unlit);
 												if (trianglecolor!=null) {
-													if (copytriangle[0].norm.isZero()) {
+													if ((bounces<=0)||(copytriangle[0].norm.isZero())) {
 														g2.setComposite(AlphaComposite.SrcOver);
 													} else {
 														g2.setComposite(AlphaComposite.Src);
@@ -940,7 +940,7 @@ public class RenderLib {
 															zbuffer[n] = drawdistance;
 															Color trianglecolor = trianglePixelShader(campos[0], copytriangle[0], copytrianglenormal[0], lineuv, camray[0], unlit);
 															if (trianglecolor!=null) {
-																if (copytriangle[0].norm.isZero()) {
+																if ((bounces<=0)||(copytriangle[0].norm.isZero())) {
 																	g2.setComposite(AlphaComposite.SrcOver);
 																} else {
 																	g2.setComposite(AlphaComposite.Src);
@@ -1058,7 +1058,7 @@ public class RenderLib {
 											}
 											Color trianglecolor = trianglePixelShader(raypos[0], copytriangle[0], copytrianglenormal[0], pointuv, raydir[0], unlit);
 											if (trianglecolor!=null) {
-												if (copytriangle[0].norm.isZero()) {
+												if ((bounces<=0)||(copytriangle[0].norm.isZero())) {
 													rendercolor[k] = MathLib.sourceOverBlend(rendercolor[k], trianglecolor, 1.0f);
 												} else {
 													rendercolor[k] = trianglecolor;

--- a/src/fi/jkauppa/javarenderengine/UtilLib.java
+++ b/src/fi/jkauppa/javarenderengine/UtilLib.java
@@ -85,6 +85,11 @@ public class UtilLib {
 		} catch (Exception ex) {ex.printStackTrace();}
     }
 	
+	public static void saveImage(String filename, VolatileImage image, String format) {
+		File savefile = new File(filename);
+		try {ImageIO.write(image.getSnapshot(), format, savefile);} catch (Exception ex) {ex.printStackTrace();}
+	}
+    
 	public static VolatileImage loadImage(String filename, boolean loadresourcefromjar) {
 		VolatileImage k = null;
 		if (filename!=null) {


### PR DESCRIPTION
Updated renderView functions to always render last bounce transparent surface as double sided thin transparent film in RenderLib.
Added key binding F4 and SHIFT-F4 to render and save 4K image with default black background using current lighting mode and transparent background with SHIFT down in CADApp.